### PR TITLE
Third Party: Update links to reflect new github organization structure

### DIFF
--- a/software/third-party/en.md
+++ b/software/third-party/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Third Party"
-lastmod = "2017-04-13T17:39:14+03:00"
+lastmod = "2018-10-25T18:21:27+02:00"
 +++
 # Third Party
 
@@ -8,28 +8,28 @@ The following applications are provided via our 3rd Party Repository to facilita
 
 Alongside the following commands, you may also find some of these applications via the Third Party section on our Software Center.
 
-If these instructions fail to work please [file an issue](https://github.com/solus-project/3rd-Party). To upgrade once installed simply run the commands again. If there is a new version it will be installed.
+If these instructions fail to work please [file an issue](https://github.com/getsolus/3rd-Party). To upgrade once installed simply run the commands again. If there is a new version it will be installed.
 
 ## Browsers
 
 ### Google Chrome
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/web/browser/google-chrome-stable/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-stable/pspec.xml
 sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ```
 
 ### Google Chrome (Beta)
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/web/browser/google-chrome-beta/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-beta/pspec.xml
 sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ```
 
 ### Google Chrome (Dev/Unstable)
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/web/browser/google-chrome-unstable/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-unstable/pspec.xml
 sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ```
 
@@ -38,35 +38,35 @@ sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ### Franz
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/im/franz/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/franz/pspec.xml
 sudo eopkg it franz*.eopkg;sudo rm franz*.eopkg
 ```
 
 ### Google Talk Browser Plugin
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/im/google-talkplugin/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/google-talkplugin/pspec.xml
 sudo eopkg it google-talkplugin*.eopkg;sudo rm google-talkplugin*.eopkg
 ```
 
 ### Skype for Linux
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/im/skype/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/skype/pspec.xml
 sudo eopkg it skype*.eopkg;sudo rm *.eopkg
 ```
 
 ### Slack
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/im/slack-desktop/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/slack-desktop/pspec.xml
 sudo eopkg it slack-desktop*.eopkg;sudo rm slack-desktop*.eopkg
 ```
 
 ### Viber
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/im/viber/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/viber/pspec.xml
 sudo eopkg it viber*.eopkg;sudo rm *.eopkg
 ```
 
@@ -77,7 +77,7 @@ sudo eopkg it viber*.eopkg;sudo rm *.eopkg
 The NPAPI version of Adobe Flash Player is typically used with Firefox.
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/video/flash-player-npapi/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/video/flash-player-npapi/pspec.xml
 sudo eopkg it flash-player-npapi*.eopkg;sudo rm flash-player-npapi*.eopkg
 ```
 
@@ -86,35 +86,35 @@ sudo eopkg it flash-player-npapi*.eopkg;sudo rm flash-player-npapi*.eopkg
 The PPAPI version of Adobe Flash Player is typically used with Vivaldi. Chrome provides its own Flash.
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/video/flash-player-ppapi/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/video/flash-player-ppapi/pspec.xml
 sudo eopkg it flash-player-ppapi*.eopkg;sudo rm flash-player-ppapi*.eopkg
 ```
 
 ### Bitwig Studio
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/music/bitwig-studio/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/bitwig-studio/pspec.xml
 sudo eopkg it bitwig-studio*.eopkg;sudo rm bitwig-studio*.eopkg
 ```
 
 ### OcenAudio
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/music/ocenaudio/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/ocenaudio/pspec.xml
 sudo eopkg it ocenaudio*.eopkg;sudo rm ocenaudio*.eopkg
 ```
 
 ### Pixeluvo
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/graphics/pixeluvo/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/graphics/pixeluvo/pspec.xml
 sudo eopkg it pixeluvo*.eopkg;sudo rm pixeluvo*.eopkg
 ```
 
 ### Plex Media Server
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/video/plexmediaserver/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/video/plexmediaserver/pspec.xml
 sudo eopkg it plexmediaserver-*.eopkg;sudo rm plexmediaserver-*.eopkg
 sudo systemd-tmpfiles --create
 sudo systemctl start plexmediaserver.service
@@ -129,14 +129,14 @@ sudo systemctl enable plexmediaserver.service
 ### Sunvox
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/music/sunvox/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/sunvox/pspec.xml
 sudo eopkg it sunvox*.eopkg;sudo rm sunvox*.eopkg
 ```
 
 ### Spotify
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/music/spotify/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/spotify/pspec.xml
 sudo eopkg it spotify*.eopkg;sudo rm spotify*.eopkg
 ```
 
@@ -145,35 +145,35 @@ sudo eopkg it spotify*.eopkg;sudo rm spotify*.eopkg
 ### AnyDesk
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/util/anydesk/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/util/anydesk/pspec.xml
 sudo eopkg it anydesk*.eopkg;sudo rm anydesk*.eopkg
 ```
 
 ### Insync
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/download/insync/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/insync/pspec.xml
 sudo eopkg it insync*.eopkg;sudo rm insync*.eopkg
 ```
 
 ### Spideroak
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/download/spideroak/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/spideroak/pspec.xml
 sudo eopkg it spideroak*.eopkg;sudo rm spideroak*.eopkg
 ```
 
 ### Synology Cloud Station Drive
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/download/synology-cloud-station-drive/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/synology-cloud-station-drive/pspec.xml
 sudo eopkg it synology-cloud-station-drive*.eopkg;sudo rm synology-cloud-station-drive*.eopkg
 ```
 
 ### TeamViewer
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/util/teamviewer/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/util/teamviewer/pspec.xml
 sudo eopkg it teamviewer*.eopkg;sudo rm teamviewer*.eopkg
 sudo systemctl start teamviewerd.service
 ```
@@ -183,42 +183,42 @@ sudo systemctl start teamviewerd.service
 ### Mendeley Desktop
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/office/mendeleydesktop/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/mendeleydesktop/pspec.xml
 sudo eopkg it mendeleydesktop*.eopkg;sudo rm mendeleydesktop*.eopkg
 ```
 
 ### Microsoft Core Fonts
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/desktop/font/mscorefonts/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/desktop/font/mscorefonts/pspec.xml
 sudo eopkg it mscorefonts*.eopkg;sudo rm mscorefonts*.eopkg
 ```
 
 ### Moneydance
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/office/moneydance/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/moneydance/pspec.xml
 sudo eopkg it moneydance*.eopkg;sudo rm moneydance*.eopkg
 ```
 
 ### PomoDoneApp
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/office/pomodoneapp/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/pomodoneapp/pspec.xml
 sudo eopkg it pomodoneapp*.eopkg;sudo rm pomodoneapp*.eopkg
 ```
 
 ### Scrivener
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/office/scrivener/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/scrivener/pspec.xml
 sudo eopkg it scrivener*.eopkg;sudo rm scrivener*.eopkg
 ```
 
 ### WPS Office
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/office/wps-office/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/wps-office/pspec.xml
 sudo eopkg it wps-office*.eopkg;sudo rm wps-office*.eopkg
 ```
 
@@ -227,84 +227,84 @@ sudo eopkg it wps-office*.eopkg;sudo rm wps-office*.eopkg
 ### Android Studio
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/android-studio/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/android-studio/pspec.xml
 sudo eopkg it android-studio*.eopkg;sudo rm android-studio*.eopkg
 ```
 
 ### Android Tools
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/tools/android-tools/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/tools/android-tools/pspec.xml
 sudo eopkg it android-tools*.eopkg;sudo rm android-tools*.eopkg
 ```
 
 ### CLion
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/clion/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/clion/pspec.xml
 sudo eopkg it clion*.eopkg;sudo rm clion*.eopkg
 ```
 
 ### Datagrip
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/datagrip/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/datagrip/pspec.xml
 sudo eopkg it datagrip*.eopkg;sudo rm datagrip*.eopkg
 ```
 
 ### Git Kraken
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/gitkraken/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/gitkraken/pspec.xml
 sudo eopkg it gitkraken*.eopkg;sudo rm gitkraken*.eopkg
 ```
 
 ### IDEA
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/idea/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/idea/pspec.xml
 sudo eopkg it idea*.eopkg;sudo rm idea*.eopkg
 ```
 
 ### PHPStorm
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/phpstorm/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/phpstorm/pspec.xml
 sudo eopkg it phpstorm*.eopkg;sudo rm phpstorm*.eopkg
 ```
 
 ### Pycharm
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/pycharm/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/pycharm/pspec.xml
 sudo eopkg it pycharm*.eopkg;sudo rm pycharm*.eopkg
 ```
 
 ### Rider
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/rider/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/rider/pspec.xml
 sudo eopkg it rider*.eopkg;sudo rm rider*.eopkg
 ```
 
 ### RubyMine
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/rubymine/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/rubymine/pspec.xml
 sudo eopkg it rubymine*.eopkg;sudo rm rubymine*.eopkg
 ```
 
 ### Sublime Text 3
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/sublime-text-3/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/sublime-text-3/pspec.xml
 sudo eopkg it sublime*.eopkg;sudo rm sublime*.eopkg
 ```
 
 ### WebStorm
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/programming/webstorm/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/webstorm/pspec.xml
 sudo eopkg it webstorm*.eopkg;sudo rm webstorm*.eopkg
 ```
 
@@ -313,7 +313,7 @@ sudo eopkg it webstorm*.eopkg;sudo rm webstorm*.eopkg
 ### Enpass
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/security/enpass/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/security/enpass/pspec.xml
 sudo eopkg it enpass*.eopkg;sudo rm enpass*.eopkg
 ```
 
@@ -322,6 +322,6 @@ sudo eopkg it enpass*.eopkg;sudo rm enpass*.eopkg
 ### Google Earth
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/solus-project/3rd-party/master/network/web/google-earth/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/google-earth/pspec.xml
 sudo eopkg it google-earth*.eopkg;sudo rm google-earth*.eopkg
 ```


### PR DESCRIPTION
## Description
The help center docs for Third Party Software still link to the old github organizations repos, which are outdated by now. Users following the instructions will in many cases either get failed downloads or outdated software. This PR changes all links (including the File an Issue one) to the new organization.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
