### PR TITLE
Add script for auto-updating timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ lastmod = "2018-03-03T14:41:12+02:00"
 +++
 ```
 
+You can also run the `update-lastmod.sh` script (located in the root of the repository) to automatically update the timestamp for a particular file
+
+```
+./update-lastmod.sh installation/disks/en.md
+```
+
+or for all markdown files that are currently modified in your working directory
+
+```
+./update-lastmod.sh
+```
+
 ### Multi-Lingual Documents
 
 Note that multi-lingual documents are not yet supported on our Help Center. When it does, we'll be happy to accept non-English language documents.

--- a/update-lastmod.sh
+++ b/update-lastmod.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+function usage {
+    echo "Usage: update-lastmod.sh [file]"
+    echo ""
+    echo "Updates the lastmod field in TOML headers to the current"
+    echo "system time in ISO 8601 format. If no file is specified,"
+    echo "all markdown files that are currently changed in the git"
+    echo "working directory are processed (except for README.md)."
+    echo ""
+    echo "  -h    Display this message and exit"
+}
+
+while getopts ":h" opt; do
+    case "$opt" in
+        *)
+            usage
+            exit 0
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+lastmod=$(date --iso-8601=seconds)
+echo "New timestamp: $lastmod"
+
+function update_file {
+    echo "Updating $1"
+    sed -i "s/lastmod = \".*\"/lastmod = \"$lastmod\"/" "$1"
+}
+
+if [[ $# -gt 0 ]]; then
+    if [[ -f "$1" && "$1" =~ .*\.md ]]; then
+        update_file "$1"
+    fi
+else
+    while read -r file; do
+        update_file "$file"
+    done < <(git diff --name-only --diff-filter=d -- "*.md" | grep -v "README.md")
+fi


### PR DESCRIPTION
This adds a `update-lastmod.sh` script to serve as a convenience utility for automatically updating `lastmod` TOML header fields to the current system time. The script can either process a single
specified file or run on all markdown files that are currently changed in the git working directory.

## Description

I kept forgetting the particular command to generate the timestamp in the required format so I threw together this silly script to just update the timestamp in the files I modified for me.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
