### PR TITLE
kwallet: Add documentation for managing SSH keys

### DIFF
--- a/software/kwallet/en.md
+++ b/software/kwallet/en.md
@@ -2,7 +2,7 @@
 title = "KDE Wallet and SSH keys"
 lastmod = "2019-03-16T14:50:00+01:00"
 +++
-# Using KDE Wallet to manage SSH key passphrases on Solus KDE Plasma Desktop
+# KDE Wallet and SSH keys
 
 In KDE Plasma, the KDE Wallet is responsible for securely storing and supplying user credentials to the various KDE applications that request them.
 
@@ -26,7 +26,9 @@ On the Solus KDE Plasma Desktop spin, `ksshaskpass` is installed out of the box 
 
 The contents of `~/.config/autostart-scripts/ssh-add.sh` should reflect the SSH keys you want to manage using the KDE Wallet.
 
-### Example `.config/autostart-scripts/ssh-add.sh` contents
+### Example
+
+Below is an example of the contents of `.config/autostart-scripts/ssh-add.sh`:
 
 ```
 #!/bin/ssh
@@ -36,9 +38,9 @@ ssh-add $HOME/.ssh/id_rsa $HOME/.ssh/solus_id_rsa </dev/null
 
 After creating this file, you will need to make it executable:
 
-`$ chmod a+x ~/.config/autostart-scripts/ssh-add.sh`
+`chmod a+x ~/.config/autostart-scripts/ssh-add.sh`
 
-## Log out and log back in to test your changes
+## Re-log in to test your changes
 
 After logging out and back in, you should now be prompted by the KDE Wallet to input your SSH key passphrases.
 

--- a/software/kwallet/en.md
+++ b/software/kwallet/en.md
@@ -4,14 +4,11 @@ lastmod = "2019-03-16T14:50:00+01:00"
 +++
 # Using KDE Wallet to manage SSH key passphrases on Solus KDE Plasma Desktop
 
-In KDE Plasma, the KDE Wallet is responsible for securely storing and supplying
-user credentials to the various KDE applications that request them.
+In KDE Plasma, the KDE Wallet is responsible for securely storing and supplying user credentials to the various KDE applications that request them.
 
-Out of the box, the Solus KDE Plasma Desktop is already configured to use the
-KDE Wallet PAM module, which unlocks the KDE Wallet on session login.
+Out of the box, the Solus KDE Plasma Desktop is already configured to use the KDE Wallet PAM module, which unlocks the KDE Wallet on session login.
 
-However, additional configuration is needed to make the KDE Wallet manage
-SSH key passphrases.
+However, additional configuration is needed to make the KDE Wallet manage SSH key passphrases.
 
 ## Prerequisites
 
@@ -21,17 +18,13 @@ For more information, see [working with SSH key passphrases](https://help.github
 
 ## The `SSH_ASKPASS` environment variable
 
-The `SSH_ASKPASS` environment variable tells the SSH subsystem which application
-to use when prompting the user for SSH key passphrases.
+The `SSH_ASKPASS` environment variable tells the SSH subsystem which application to use when prompting the user for SSH key passphrases.
 
-On the Solus KDE Plasma Desktop spin, `ksshaskpass` is installed out of the box
-and `SSH_ASKPASS` is set to `ksshaskpass` in the file
-`/usr/share/xdg/plasma-workspace/env/50-solus-defaults.sh` by default.
+On the Solus KDE Plasma Desktop spin, `ksshaskpass` is installed out of the box and `SSH_ASKPASS` is set to `ksshaskpass` in the file `/usr/share/xdg/plasma-workspace/env/50-solus-defaults.sh` by default.
 
 ## Create `~/.config/autostart-scripts/ssh-add.sh` 
 
-The contents of `~/.config/autostart-scripts/ssh-add.sh` should reflect the SSH
-keys you want to manage using the KDE Wallet.
+The contents of `~/.config/autostart-scripts/ssh-add.sh` should reflect the SSH keys you want to manage using the KDE Wallet.
 
 ### Example `.config/autostart-scripts/ssh-add.sh` contents
 
@@ -47,12 +40,10 @@ After creating this file, you will need to make it executable:
 
 ## Log out and log back in to test your changes
 
-After logging out and back in, you should now be prompted by the KDE Wallet
-to input your SSH key passphrases.
+After logging out and back in, you should now be prompted by the KDE Wallet to input your SSH key passphrases.
 
 ## Unlock SSH key passphrases automatically on login
 
 KDE Wallet supports automatically unlocking your SSH key passphrases on login.
 
-For this to work, your KDE Wallet password needs to be identical to your login
-password.
+For this to work, your KDE Wallet password needs to be identical to your login password.

--- a/software/kwallet/en.md
+++ b/software/kwallet/en.md
@@ -40,7 +40,7 @@ After creating this file, you will need to make it executable:
 
 `chmod a+x ~/.config/autostart-scripts/ssh-add.sh`
 
-## Re-log in to test your changes
+## Re-log to test your changes
 
 After logging out and back in, you should now be prompted by the KDE Wallet to input your SSH key passphrases.
 

--- a/software/kwallet/en.md
+++ b/software/kwallet/en.md
@@ -1,0 +1,58 @@
++++
+title = "KDE Wallet and SSH keys"
+lastmod = "2019-03-16T14:50:00+01:00"
++++
+# Using KDE Wallet to manage SSH key passphrases on Solus KDE Plasma Desktop
+
+In KDE Plasma, the KDE Wallet is responsible for securely storing and supplying
+user credentials to the various KDE applications that request them.
+
+Out of the box, the Solus KDE Plasma Desktop is already configured to use the
+KDE Wallet PAM module, which unlocks the KDE Wallet on session login.
+
+However, additional configuration is needed to make the KDE Wallet manage
+SSH key passphrases.
+
+## Prerequisites
+
+This document assumes that you are familiar with utilising SSH key passphrases.
+
+For more information, see [working with SSH key passphrases](https://help.github.com/en/articles/working-with-ssh-key-passphrases)
+
+## The `SSH_ASKPASS` environment variable
+
+The `SSH_ASKPASS` environment variable tells the SSH subsystem which application
+to use when prompting the user for SSH key passphrases.
+
+On the Solus KDE Plasma Desktop spin, `ksshaskpass` is installed out of the box
+and `SSH_ASKPASS` is set to `ksshaskpass` in the file
+`/usr/share/xdg/plasma-workspace/env/50-solus-defaults.sh` by default.
+
+## Create `~/.config/autostart-scripts/ssh-add.sh` 
+
+The contents of `~/.config/autostart-scripts/ssh-add.sh` should reflect the SSH
+keys you want to manage using the KDE Wallet.
+
+### Example `.config/autostart-scripts/ssh-add.sh` contents
+
+```
+#!/bin/ssh
+
+ssh-add $HOME/.ssh/id_rsa $HOME/.ssh/solus_id_rsa </dev/null
+```
+
+After creating this file, you will need to make it executable:
+
+`$ chmod a+x ~/.config/autostart-scripts/ssh-add.sh`
+
+## Log out and log back in to test your changes
+
+After logging out and back in, you should now be prompted by the KDE Wallet
+to input your SSH key passphrases.
+
+## Unlock SSH key passphrases automatically on login
+
+KDE Wallet supports automatically unlocking your SSH key passphrases on login.
+
+For this to work, your KDE Wallet password needs to be identical to your login
+password.


### PR DESCRIPTION
## Description

KDE Wallet: Add documentation for managing SSH keys.

Additional configuration is necessary if one wants to use the KDE Wallet
to manage SSH keys.

Adapted for the Solus KDE Plasma Desktop from an Arch Linux Wiki entry.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
