### PR TITLE
Add Nvidia 390 driver to Steam help page

### DIFF
--- a/gaming/steam/en.md
+++ b/gaming/steam/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Steam"
-lastmod = "2018-10-20T13:39:48+03:00"
+lastmod = "2019-03-19T19:45:43+01:00"
 +++
 # Steam
 
@@ -11,4 +11,5 @@ Steam is currently available via the Solus repository, as the `steam` package.
 For systems running NVIDIA graphics hardware, you will need to install the corresponding 32bit video driver for your card, listed below:
 
 - Current Gen: `nvidia-glx-driver-32bit`
+- 390: `nvidia-390-glx-driver-32bit`
 - 340: `nvidia-340-glx-driver-32bit`


### PR DESCRIPTION
## Description

Add info for the nvidia-390-glx-driver to the Steam help page (this package didn't exist back when this was written).
I've not included the developer and beta drivers, because they are "use at your own risk" anyway, but can add them if you think it would be better.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
