### PR TITLE
Fixed error caused by missing 'libgconf-2.so.4'

### DIFF
--- a/gaming/minecraft/en.md
+++ b/gaming/minecraft/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Minecraft"
-lastmod = "2019-03-18T01:36:02+01:00"
+lastmod = "2019-04-30T23:31:12+02:00"
 +++
 # Minecraft
 
@@ -10,10 +10,10 @@ lastmod = "2019-03-18T01:36:02+01:00"
 
 ## Installation
 
-Install Java and download Minecraft:
+Install dependencies and download Minecraft:
 
 ``` bash
-sudo eopkg it openjdk-8
+sudo eopkg it openjdk-8 gconf
 sudo mkdir -p /opt/minecraft
 sudo wget https://launcher.mojang.com/download/Minecraft.tar.gz -O /opt/minecraft/Minecraft.tar.gz
 ```


### PR DESCRIPTION
## Description

Added installation of gconf to Minecraft instructions, to satisfy the missing `libgconf-2.so.4` dependency:

```minecraft-launcher: error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory```

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
