### PR TITLE
kwallet HOWTO: Fix rather unfortunate typo

### DIFF
--- a/software/kwallet/en.md
+++ b/software/kwallet/en.md
@@ -1,6 +1,6 @@
 +++
 title = "KDE Wallet and SSH keys"
-lastmod = "2019-03-16T14:50:00+01:00"
+lastmod = "2019-09-17T55:50:00+02:00"
 +++
 # KDE Wallet and SSH keys
 
@@ -31,7 +31,7 @@ The contents of `~/.config/autostart-scripts/ssh-add.sh` should reflect the SSH 
 Below is an example of the contents of `.config/autostart-scripts/ssh-add.sh`:
 
 ```
-#!/bin/ssh
+#!/bin/sh
 
 ssh-add $HOME/.ssh/id_rsa $HOME/.ssh/solus_id_rsa </dev/null
 ```


### PR DESCRIPTION
## Description

Fix essential typo that prevents the guide from working.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
