### PR TITLE
Update chroot instructions in Boot Rescue

### DIFF
--- a/troubleshooting/boot-rescue/en.md
+++ b/troubleshooting/boot-rescue/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Boot Rescue"
-lastmod = "2020-04-10T10:39:18+03:00"
+lastmod = "2020-08-01T12:21:00+02:00"
 +++
 # Boot Rescue
 
@@ -92,9 +92,11 @@ First run the following commands:
 
 
 ``` bash
-mount --bind /proc /target/proc
-mount --bind /dev /target/dev
-mount --bind /sys /target/sys
+mount --types proc /proc /target/proc
+mount --rbind /dev /target/dev
+mount --rbind /sys /target/sys
+mount --make-rslave /target/dev
+mount --make-rslave /target/sys
 ```
 
 Assuming all goes well, you should now be able to chroot into your Solus system by doing `chroot /target`.


### PR DESCRIPTION
## Description

Current instructions do not mount EFI-vars correctly. Therefore `clr-boot-manager update` or `bootctl install` won't work. 

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
