### PR TITLE
Add output to eopkg index command

### DIFF
--- a/packaging/local-repository/en.md
+++ b/packaging/local-repository/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Packaging Using a Local Repository"
-lastmod = "2019-06-10T22:50:00+02:00"
+lastmod = "2020-06-17T00:06:42+00:00"
 +++
 # Packaging Using a Local Repository
 
@@ -47,7 +47,7 @@ As mentioned earlier, the local solbuild repo installed by the `solbuild-config-
 
 To generate or refresh the eopkg index in `/var/lib/solbuild/local`, simply run:
 
-`sudo eopkg index --skip-signing /var/lib/solbuild/local/`
+`sudo eopkg index --skip-signing /var/lib/solbuild/local/ --output /var/lib/solbuild/local/eopkg-index.xml`
 
 ### A note on package resolution priority
 


### PR DESCRIPTION
## Description

The guide tells you to run `sudo eopkg index --skip-signing /var/lib/solbuild/local/` followed by `sudo eopkg ar Local /var/lib/solbuild/local/eopkg-index.xml.xz`, without mentioning the fact that `eopkg index` puts the index file in the current directory by default and unless your working directory is `/var/lib/solbuild/local` the file `/var/lib/solbuild/local/eopkg-index.xml.xz` will not exist and `eopkg` will not find it.

This change amends the first command to be `sudo eopkg index --skip-signing /var/lib/solbuild/local/ --output /var/lib/solbuild/local/eopkg-index.xml` so that running the second command will work.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
