### PR TITLE
Remove KDE Plasma Desktop from the Desktop Environments HOWTO

### DIFF
--- a/software/desktop-environments/en.md
+++ b/software/desktop-environments/en.md
@@ -13,6 +13,7 @@ WARNING: Do NOT attempt to install ANY other desktop environments next to KDE Pl
 The flagship desktop environment / experience of Solus is Budgie. If you have installed either our MATE or GNOME editions, you can try out and install Budgie by running the following command:
 
 ``` bash
+# Do NOT attempt to do this if you are running the KDE Plasma Desktop version of Solus!
 sudo eopkg install -c desktop.budgie
 ```
 
@@ -21,6 +22,7 @@ sudo eopkg install -c desktop.budgie
 Solus offers a GNOME Shell experience that ships out-of-the-box with a variety of extensions. If you have installed either our Budgie or MATE editions, you can try out and install GNOME Shell by running the following commands:
 
 ``` bash
+# Do NOT attempt to do this if you are running the KDE Plasma Desktop version of Solus!
 sudo eopkg rm lightdm
 sudo eopkg install gdm gnome-shell gnome-desktop-branding-fortitude
 ```
@@ -30,6 +32,7 @@ sudo eopkg install gdm gnome-shell gnome-desktop-branding-fortitude
 Solus offers the MATE desktop environment / experience, tailored to advanced users and older hardware, as well as shipping with our modern menu called [Brisk Menu](https://github.com/getsolus/brisk-menu). If you have installed either our Budgie or GNOME editions, you can try out and install MATE by running the following command:
 
 ``` bash
+# Do NOT attempt to do this if you are running the KDE Plasma Desktop version of Solus!
 sudo eopkg install -c desktop.mate
 ```
 
@@ -38,6 +41,7 @@ sudo eopkg install -c desktop.mate
 Solus offers i3 as a tiling window manager. Users wanting to try i3 can install it by running the following command:
 
 ``` bash
+# Do NOT attempt to do this if you are running the KDE Plasma Desktop version of Solus!
 sudo eopkg install i3
 ```
 

--- a/software/desktop-environments/en.md
+++ b/software/desktop-environments/en.md
@@ -1,10 +1,12 @@
 +++
 title = "Desktop Environments"
-lastmod = "2020-04-01T19:44:25-04:00"
+lastmod = "2020-05-20T21:05:00+02:00"
 +++
 # Desktop Environments
 
-Solus offers a [multitude of desktop environments](/solus/experiences/), ranging from the feature-rich and modern Budgie to the traditional MATE experience. It is recommended to use the ISO for a specific desktop environment but it is possible to install them afterwards if you wish to do try one out.  
+Solus offers a [multitude of desktop environments](/solus/experiences/), ranging from the feature-rich and modern Budgie to the traditional MATE experience. It is recommended to use the ISO for a specific desktop environment but it is possible to install them afterwards if you wish to do try one out.
+
+WARNING: Do NOT attempt to install ANY other desktop environments next to KDE Plasma Desktop. This scenario is NOT supported and you will be told so in no uncertain terms if asking for support.
 
 ## Budgie
 
@@ -29,14 +31,6 @@ Solus offers the MATE desktop environment / experience, tailored to advanced use
 
 ``` bash
 sudo eopkg install -c desktop.mate
-```
-
-## Plasma
-
-Solus offers the KDE Plasma desktop environment / experience, which is a powerful and highly customizable desktop environment built with Qt and the KDE framework. KDE Plasma can be installed by running the following command:
-
-``` bash
-sudo eopkg install -c desktop.kde.core
 ```
 
 ## i3


### PR DESCRIPTION
This was done at the request of the KDE Plasma Desktop and GNOME Shell maintainers as being able to switch to/from KDE from e.g. GNOME Shell is not something they wish to support.

## Description

 Remove KDE Plasma Desktop from the Desktop Environments HOWTO and add a warning so people don't try to install other DE's next to KDE Plasma Desktop.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
