### PR TITLE
changing-shell: fix fish path

### DIFF
--- a/configuration/changing-shell/en.md
+++ b/configuration/changing-shell/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Changing Shell"
-lastmod = "2020-04-10T15:10:59-04:00"
+lastmod = "2020-11-05T15:10:59-04:00"
 +++
 # Changing Shell
 
@@ -28,9 +28,9 @@ To switch to another shell, first install the appropriate package, followed by t
 
 Example:
 
-- For Zsh: `chsh -s /bin/zsh`
+- For Zsh: `sudo chsh -s /bin/zsh`
 
-- For Fish: `chsh -s /bin/fish`
+- For Fish: `sudo chsh -s /usr/bin/fish`
 
 ## Troubleshooting
 


### PR DESCRIPTION
Signed-off-by: Pierre-Yves <pyu@riseup.net>

## Description

Fish is installed in `/usr/bin` and not in `/bin`. Also add `sudo` in `chsh` command examples to be consistent with the other commands on the same page

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [ ] Squashed commits with `git rebase -i` (if needed)
