### PR TITLE
Make it clear partial updates are not supported

### DIFF
--- a/common-tasks/installing-and-updating-software/en.md
+++ b/common-tasks/installing-and-updating-software/en.md
@@ -1,9 +1,11 @@
 +++
 title = "Installing and updating software"
-lastmod = "2017-03-11T00:40:25+02:00"
+lastmod = "2020-12-23T13:03:32+11:00"
 +++
 # Installing and updating software
 
 You can install software ranging from Google Chrome to LibreOffice, as well as updating software, via our Software Center.
+
+Please note partial updates are not supported, they are a common cause of breakages. You should always upgrade every package.
 
 {{< altimg "solus-sc.jpg" "help-center/common-tasks/installing-and-updating-software/" >}}

--- a/package-management/basics/en.md
+++ b/package-management/basics/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Basics to Package Management"
-lastmod = "2017-02-26T23:30:09+02:00"
+lastmod = "2020-12-23T13:03:32+11:00"
 +++
 # Basics to Package Management
 
@@ -71,7 +71,9 @@ You can update your system by using:
 sudo eopkg upgrade
 ```
 
-If you want to **only** update a specific piece of software on your system, you can specify is like below:
+Please note partial updates are not supported, they are a common cause of breakages. You should always upgrade every package.
+
+However if you want to **only** update a specific piece of software on your system, you can specify what package like the following example:
 
 ``` bash
 sudo eopkg upgrade firefox


### PR DESCRIPTION
## Description

Make it clear partial updates are not supported. While most people do not read the help center documentation, it might stop some from breaking their systems due to unwittingly selecting critical updates only until that section can be removed from solus-sc.

I assume this is what is responsible for this issue. https://discuss.getsol.us/d/3493-oh-no-something-went-wrong-the-system-can-t-recover/10

### Submitter Checklist

- [X] Updated the "lastmod" portion at the top of any modified Markdown files.
- [X] Squashed commits with `git rebase -i` (if needed)
