### PR TITLE
Update packages to build Android R or Lineage-18.1

### DIFF
--- a/software/building-android/en.md
+++ b/software/building-android/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Building Android"
-lastmod = "2019-06-12T01:15:41+03:00"
+lastmod = "2021-04-17T15:09:28+05:30"
 +++
 # Building Android™ on Solus
 
@@ -31,7 +31,7 @@ sudo eopkg it -c system.devel
 Now we'll need to install the rest of the required build dependencies.
 
 ``` bash
-sudo eopkg it curl-devel git gnupg gperf libgcc-32bit libxslt-devel lzop ncurses-32bit-devel ncurses-devel readline-32bit-devel rsync schedtool sdl1-devel squashfs-tools unzip wxwidgets-devel zip zlib-32bit-devel
+sudo eopkg it curl-devel dejavu-fonts-ttf git gnupg gperf libgcc-32bit libxslt-devel lzop ncurses-32bit-devel ncurses-devel readline-32bit-devel rsync schedtool sdl1-devel squashfs-tools unzip wxwidgets-devel zip zlib-32bit-devel
 ```
 
 ### Installing the `repo` Tool


### PR DESCRIPTION
* dejavu-fonts-ttf is required to build recovery image

## Description

<Adds necessary packages to build Android R ( lineage-18.1)>

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [ ] Squashed commits with `git rebase -i` (if needed)
