### PR TITLE
Third Party: Update sublime text package name and URLs to new scheme

### DIFF
--- a/software/third-party/en.md
+++ b/software/third-party/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Third Party"
-lastmod = "2021-09-06T22:57:50+02:00"
+lastmod = "2021-09-14T20:38:59+02:00"
 +++
 # Third Party
 
@@ -255,10 +255,10 @@ sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-par
 sudo eopkg it rubymine*.eopkg;sudo rm rubymine*.eopkg
 ```
 
-### Sublime Text 3
+### Sublime Text
 
 ``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/sublime-text-3/pspec.xml
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/sublime-text/pspec.xml
 sudo eopkg it sublime*.eopkg;sudo rm sublime*.eopkg
 ```
 


### PR DESCRIPTION
## Description

This updates the name and URLs for the (Third Party) sublime text package to conform to the corresponding restructure in the Third Party repository: getsolus/3rd-party#55

This will have to be committed/pushed at the same time as the Third Party repo PR to avoid confusion due to error messages on user's systems.

See also the same change for solus-sc: https://github.com/getsolus/solus-sc/pull/103

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
