### PR TITLE
Remove Pixeluvo from Third Party

### DIFF
--- a/software/third-party/en.md
+++ b/software/third-party/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Third Party"
-lastmod = "2021-01-14T01:48:54+01:00"
+lastmod = "2021-09-06T22:57:50+02:00"
 +++
 # Third Party
 
@@ -84,13 +84,6 @@ sudo eopkg it bitwig-studio*.eopkg;sudo rm bitwig-studio*.eopkg
 ``` bash
 sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/ocenaudio/pspec.xml
 sudo eopkg it ocenaudio*.eopkg;sudo rm ocenaudio*.eopkg
-```
-
-### Pixeluvo
-
-``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/graphics/pixeluvo/pspec.xml
-sudo eopkg it pixeluvo*.eopkg;sudo rm pixeluvo*.eopkg
 ```
 
 ### Plex Media Server


### PR DESCRIPTION
## Description

Removes Pixeluvo from the Third Party section. It requires Qt4 and is thus no longer usable on Solus.

Corresponding 3rd-party PR: https://github.com/getsolus/3rd-party/pull/60

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
