### PR TITLE
Add a section on setting up the OBS Virtual Camera

### DIFF
--- a/software/open-broadcaster-software/en.md
+++ b/software/open-broadcaster-software/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Open Broadcaster Software"
-lastmod = "2018-03-03T14:41:12+02:00"
+lastmod = "2021-09-17T10:58:31-04:00"
 +++
 # Open Broadcaster Software
 
@@ -13,6 +13,28 @@ To install OBS Studio, either open up the Software Center and type `obs-studio` 
 ``` bash
 sudo eopkg install obs-studio
 ```
+## Virtual Camera
+
+OBS includes a virtual webcam device which can be used to send your OBS stream to video conferencing programs. In order to use this on Solus, you must install `v4l2loopback`. There are two versions of `v4l2loopback` available in the repository, and you must choose the version that corresponds to the kernel you have installed.
+
+To find out which kernel is installed, run:
+
+```bash
+uname -r
+```
+This should return a version which ends in `.current` or `.lts`. If you are running the "current" kernel, install `v4l2loopback-current`:
+
+```bash
+sudo eopkg install v4l2loopback-current
+```
+or, if you are running the "lts" kernel, install `v4l2loopback`:
+
+```bash
+sudo eopkg install v4l2loopback
+```
+
+Once v4l2loopback is installed, reboot your computer. Next time you start OBS, it will prompt you for your password to set up v4l2loopback. After that, the virtual camera should be available as a webcam in other programs.
+
 
 ## Plugins
 

--- a/software/open-broadcaster-software/en.md
+++ b/software/open-broadcaster-software/en.md
@@ -15,23 +15,17 @@ sudo eopkg install obs-studio
 ```
 ## Virtual Camera
 
-OBS includes a virtual webcam device which can be used to send your OBS stream to video conferencing programs. In order to use this on Solus, you must install `v4l2loopback`. There are two versions of `v4l2loopback` available in the repository, and you must choose the version that corresponds to the kernel you have installed.
+OBS includes a virtual webcam device which can be used to send your OBS stream to video conferencing programs. In order to use this on Solus, you must first install from our repository a separate kernel module that is responsible for creating the necessary "loopback" device. There are two versions of this software available in the repository, you must choose the version that corresponds to the kernel you have installed.
 
 To find out which kernel is installed, run:
 
 ```bash
 uname -r
 ```
-This should return a version which ends in `.current` or `.lts`. If you are running the "current" kernel, install `v4l2loopback-current`:
+This should return a version which ends in `.current` or `.lts`.
 
-```bash
-sudo eopkg install v4l2loopback-current
-```
-or, if you are running the "lts" kernel, install `v4l2loopback`:
-
-```bash
-sudo eopkg install v4l2loopback
-```
+- If you are running the "current" kernel, install `v4l2loopback-current`: `sudo eopkg install v4l2loopback-current`
+- If you are running the "lts" kernel, install `v4l2loopback`: `sudo eopkg install v4l2loopback`
 
 Once v4l2loopback is installed, reboot your computer. Next time you start OBS, it will prompt you for your password to set up v4l2loopback. After that, the virtual camera should be available as a webcam in other programs.
 


### PR DESCRIPTION
## Description

This adds instructions for installing v4l2loopback to enable the OBS Virtual Camera.

### Submitter Checklist

- [x ] Updated the "lastmod" portion at the top of any modified Markdown files.
- [ ] Squashed commits with `git rebase -i` (if needed) - only made one commit
