### PR TITLE
Update Minecraft doc to new path

### DIFF
--- a/gaming/minecraft/en.md
+++ b/gaming/minecraft/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Minecraft"
-lastmod = "2020-05-21T22:18:52+02:00"
+lastmod = "2021-10-24T23:21:25+02:00"
 +++
 # Minecraft
 
@@ -48,7 +48,7 @@ kate /usr/share/applications/minecraft-launcher.desktop
 Now edit inside the desktop file the Exec path to the following
 
 ``` bash
-Exec=env JAVA_HOME=/usr/lib64/openjdk-8 /opt/minecraft-launcher/minecraft-launcher
+Exec=env JAVA_HOME=/usr/lib64/openjdk-8 /usr/bin/minecraft-launcher
 ```
 
 #### Integration the installed files into your system:


### PR DESCRIPTION
## Description

The path to the Minecraft Launcher seems to have changed at some point since the last update to this documentation.
It's now at `/usr/bin/minecraft-launcher `
This PR changes the documentation accordingly.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
