### PR TITLE
Improve/fix Minecraft instructions

### DIFF
--- a/gaming/minecraft/en.md
+++ b/gaming/minecraft/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Minecraft"
-lastmod = "2021-10-24T23:21:25+02:00"
+lastmod = "2022-06-20T18:46:44+02:00"
 +++
 # Minecraft
 
@@ -13,7 +13,7 @@ lastmod = "2021-10-24T23:21:25+02:00"
 Install dependencies and download Minecraft:
 
 ``` bash
-sudo eopkg it openjdk-8 gconf binutils
+sudo eopkg it gconf binutils
 wget https://launcher.mojang.com/download/Minecraft.deb
 ```
 
@@ -22,33 +22,7 @@ Extract files and remove old archive:
 ``` bash
 sudo ar xf Minecraft.deb
 sudo tar xf data.tar.xz -C /
-sudo rm control.tar.gz data.tar.xz debian-binary Minecraft.deb
-```
-
-#### Now edit the desktop file to integrate openjdk-8 environment:
-
-On Solus Budgie or Gnome:
-
-``` bash
-sudo gedit /usr/share/applications/minecraft-launcher.desktop
-```
-
-On Solus Mate:
-
-``` bash
-sudo pluma /usr/share/applications/minecraft-launcher.desktop
-```
-
-On Solus Plasma:
-
-``` bash
-kate /usr/share/applications/minecraft-launcher.desktop
-```
-
-Now edit inside the desktop file the Exec path to the following
-
-``` bash
-Exec=env JAVA_HOME=/usr/lib64/openjdk-8 /usr/bin/minecraft-launcher
+sudo rm control.tar.xz data.tar.xz debian-binary Minecraft.deb
 ```
 
 #### Integration the installed files into your system:


### PR DESCRIPTION
## Description

The structure of the minecraft.deb archive changed, and the current instructions lead to an error message and leftover files.

This updates the instructions to list the correct file extension for `control.tar.xz`

Update: Also removed the steps involved to install and configure openjdk-8. This is no longer necessary, and Minecraft will ignore the env variable and use the bundled runtime in any case (unless you also set the path to openjdk in the launcher menu itself)

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
