### PR TITLE
Remove Google Talk plugin

### DIFF
--- a/software/third-party/en.md
+++ b/software/third-party/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Third Party"
-lastmod = "2021-09-06T22:57:50+02:00"
+lastmod = "2022-06-16T19:15:04+02:00"
 +++
 # Third Party
 
@@ -40,13 +40,6 @@ sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ``` bash
 sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/franz/pspec.xml
 sudo eopkg it franz*.eopkg;sudo rm franz*.eopkg
-```
-
-### Google Talk Browser Plugin
-
-``` bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/google-talkplugin/pspec.xml
-sudo eopkg it google-talkplugin*.eopkg;sudo rm google-talkplugin*.eopkg
 ```
 
 ### Skype for Linux


### PR DESCRIPTION
## Description

This removes the Google Talk plugin instructions from the "Third Party" page.

Google has ended support, see https://support.google.com/talk/?hl=en

Corresponding PR in 3rd-party: https://github.com/getsolus/3rd-party/pull/66

Corresponding PR in solus-sc: https://github.com/getsolus/solus-sc/pull/153

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
