### PR TITLE
Package.yml: Fix link to CONFOPTS

### DIFF
--- a/packaging/package.yml/en.md
+++ b/packaging/package.yml/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Package.yml"
-lastmod = "2021-02-24T15:17:14+02:00"
+lastmod = "2022-08-11T23:50:06+02:00"
 +++
 # Package.yml
 
@@ -201,7 +201,7 @@ Macro | Description
 **%ARCH%** | Indicates the current build architecture.
 **%CC%** | C compiler
 **%CFLAGS%** | cflags as set in `eopkg.conf`
-**%CONFOPTS%** | Flags / options for configuration, such as `--prefix=%PREFIX%`. [Full List.](https://github.com/getsolus/ypkg/blob/master/ypkg2/rc.yml#L327-L329)
+**%CONFOPTS%** | Flags / options for configuration, such as `--prefix=%PREFIX%`. [Full List.](https://github.com/getsolus/ypkg/blob/master/ypkg2/rc.yml#L376-L378)
 **%CXX%** | C++ compiler
 **%CXXFLAGS%** | cxxflags as set in `eopkg.conf`
 **%JOBS%** | jobs, as set in `eopkg.conf`


### PR DESCRIPTION
## Description

This fixes the link to our CONFOPTS to point to the correct lines again (since a lot of stuff has been added in the meantime)

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
