### PR TITLE
Add 'sudo eopkg rebuild-db' to incomplete upgrade

### DIFF
--- a/troubleshooting/boot-rescue/en.md
+++ b/troubleshooting/boot-rescue/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Boot Rescue"
-lastmod = "2021-08-31T10:02:15-03:00"
+lastmod = "2022-11-10T21:55:00+01:00"
 +++
 # Boot Rescue
 
@@ -112,9 +112,10 @@ To validate a working network connection (assuming a network connection is avail
 
 In the event you had an incomplete upgrade, try the following commands:
 
-1. `sudo eopkg up`
-2. `sudo eopkg check | grep Broken | awk '{print $4}' | xargs sudo eopkg it --reinstall`
-3. Try reverting the latest package transaction (this should only be done if the first two steps, followed by the "Re-run System-Wide Configuration Triggers", failed to produce a successful bootup). See [our documentation on history and rollback](/articles/package-management/history-and-rollback/en) for more information, followed by re-applying your updates by running `sudo eopkg up`.
+1. `sudo eopkg rebuild-db`
+2. `sudo eopkg up`
+3. `sudo eopkg check | grep Broken | awk '{print $4}' | xargs sudo eopkg it --reinstall`
+4. Try reverting the latest package transaction (this should only be done if the first two steps, followed by the "Re-run System-Wide Configuration Triggers", failed to produce a successful bootup). See [our documentation on history and rollback](/articles/package-management/history-and-rollback/en) for more information, followed by re-applying your updates by running `sudo eopkg up`.
 
 ### Re-run System-Wide Configuration Triggers
 


### PR DESCRIPTION
## Description

Add `sudo eopkg rebuild-db` to the boot rescue help in case of an incomplete upgrade.

Sometimes the database gets corrupted and if someone doesn't know about that command that would help them.

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
