### PR TITLE
Move from IRC to Matrix

### DIFF
--- a/contributing/community-guidelines/en.md
+++ b/contributing/community-guidelines/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Community Guidelines"
-lastmod = "2019-03-28T15:09:45+01:00"
+lastmod = "2023-05-17T18:12:03-05:00"
 +++
 # Community Guidelines
 
@@ -14,7 +14,7 @@ The guidelines laid out in this section apply to all services offered or used by
 
 - Our Development Tracker
 - Any and all forums or organized communities, e.g. our Forums or sub-reddit
-- IRC or any other officially supported means of communicating with the project and community members in real-time
+- Matrix, IRC, or any other officially supported means of communicating with the project and community members in real-time
 - Postings to social media pages / properties owned or used by the project.
 
 ### Harassment
@@ -38,7 +38,7 @@ Members of the community are expected to engage in a manner which is respectful 
   - Political affiliation
 - Sexual or otherwise lewd in nature
 
-Profane language which is not derogatory, hateful, or sexual in nature may be allowed in specific off-topic channels or other locations permitted by the project. However, Core Team reserves the right to request the immediate ceasing of the use of such language by any individual if it is deemed to be derogatory, hateful, sexual, or in a manner which is otherwise distasteful.
+Profane language which is not derogatory, hateful, or sexual in nature may be allowed in specific off-topic rooms or other locations permitted by the project. However, Core Team reserves the right to request the immediate ceasing of the use of such language by any individual if it is deemed to be derogatory, hateful, sexual, or in a manner which is otherwise distasteful.
 
 ### Media Sharing
 
@@ -48,9 +48,9 @@ Members of the community shall not link / share media which is illegal, pornogra
 
 Members of the community should attempt to observe topic guidance when participating in various services offered or used by the project, such as:
 
-- Ensuring support-related channels / mediums remain free of development and off-topic discussions to maximize the community and team’s ability to respond and address issues or support requests.
-- Ensuring development channels / mediums remain free of off-topic discussions which are not relevant to the development or progression of various development items relating to Solus.
-- Ensuring off-topic channels / mediums remain free of heated discussions of polarizing issues or current events in order to keep these spaces inviting and enjoyable.
+- Ensuring support-related rooms / mediums remain free of development and off-topic discussions to maximize the community and team’s ability to respond and address issues or support requests.
+- Ensuring development rooms / mediums remain free of off-topic discussions which are not relevant to the development or progression of various development items relating to Solus.
+- Ensuring off-topic rooms / mediums remain free of heated discussions of polarizing issues or current events in order to keep these spaces inviting and enjoyable.
 
 ### Other
 

--- a/contributing/getting-involved/en.md
+++ b/contributing/getting-involved/en.md
@@ -15,17 +15,18 @@ The Solus Project enforces a set of community guidelines to maintain respect and
 ### Community Forums
 
 With so many new users joining, there are always more people needing help. A great way to help us out, would be to help out our users on the [Solus Project Forums](https://discuss.getsol.us).
-### IRC
 
-[Internet Relay Chat](https://en.wikipedia.org/wiki/Internet_Relay_Chat) is a great way to discuss issues and development with the community, and project developers. It's also a great place for getting support, but remember due
-to timezone differences there might not always be people present to answer your query immediately. You can access IRC using free clients like Hexchat (preinstalled on Solus) and Quassel! *Note that web IRC clients are not permitted..*
+### Matrix (chat)
 
-You will find the following Solus channels on the [Libera Chat](https://libera.chat/) IRC network:
+[Matrix](https://en.wikipedia.org/wiki/Matrix_(protocol)) is a great way to discuss issues and development with the community, and project developers in real-time. It's also a great place for getting support, but remember due
+to timezone differences there might not always be people there to answer your question immediately. You can access Matrix using a client like [Element Web](https://app.element.io/), or many [others](https://matrix.org/clients/). You will need a Matrix account.
 
-- [#Solus](irc://irc.libera.chat/#Solus) - Support channel.
-- [#Solus-Chat](irc://irc.libera.chat/#Solus-Chat) - Off-topic channel.
-- [#Solus-Dev](irc://irc.libera.chat/#Solus-Dev) - Development-related discussions.
-- [#Solus-LiveStream](irc://irc.libera.chat/#Solus-LiveStream) - Channel used for discussion during Hackfests and other official Solus live streams.
+You will find the following Solus rooms on the `matrix.org` homeserver:
+
+- [#solus-support:matrix.org](https://matrix.to/#/#solus-support:matrix.org) Support room
+- [#solus-off-topic:matrix.org](https://matrix.to/#/#solus-off-topic:matrix.org) Off-topic room
+- [#solus-development:matrix.org](https://matrix.to/#/#solus-development:matrix.org) Development-related room
+- [#solus:matrix.org](https://matrix.to/#/#solus:matrix.org) **Matrix Space containing all rooms**
 
 ### Social Media
 

--- a/packaging/maintainership/en.md
+++ b/packaging/maintainership/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Maintainership"
-lastmod = "2021-09-17T21:10:00+02:00"
+lastmod = "2023-05-17T18:12:03-05:00"
 +++
 # Maintainership
 
@@ -44,6 +44,6 @@ The contact information section is a YAML list. If needed, more elements may be 
 This file is used to indicate responsibility for the maintenance of this package. Individuals on this list should be the sole modifiers of the package, excluding cases where the Solus Team may need to perform necessary rebuilds, upgrades, or security fixes. This list should not be used for any direct contact usage. If you believe this package requires a package update, follow documentation from https://getsol.us/articles/packaging/request-a-package-update/en/. In the event this package no longer becomes sufficiently maintained, Core Team reserves the right to request a new maintainer or remove this package from the repository.
 
 - Name Surname
-  - IRC: REPLACEME
+  - Matrix: REPLACEME
   - Email: REPLACEME
 ```

--- a/packaging/submitting-a-package/en.md
+++ b/packaging/submitting-a-package/en.md
@@ -1,6 +1,6 @@
 +++
 title = "Submitting the Package"
-lastmod = "2018-12-29T00:54:53+01:00"
+lastmod = "2023-05-17T18:12:03-05:00"
 +++
 # Submitting the Package
 
@@ -35,7 +35,7 @@ Prior to submitting a patch, please ensure you are checking the following:
 
 Please refrain from submitting a patch for the following instances:
 
-- For a package that is yet to be accepted for inclusion by a member of the Triage Team. We welcome you to politely reach out via the package request task or [IRC](/articles/contributing/getting-involved/en) if you deem the review of the request to be time-sensitive in nature.
+- For a package that is yet to be accepted for inclusion by a member of the Triage Team. We welcome you to politely reach out via the package request task or [Matrix](/articles/contributing/getting-involved/en) if you deem the review of the request to be time-sensitive in nature.
 - If your patch is a Work In Progress / WIP. Completed patches or patches which have a request for comments are accepted, however for request for comments please ensure your patch title contains `[RFC]`. WIP patches just clutter Differential and make patch review by the team more time consuming and introduces unnecessary work.
 
 ## Setting up Arcanist
@@ -120,6 +120,6 @@ Pushing changes is not possible unless you have maintainer access. The same is a
 To request maintainer rights for a repository, it is expected that some level of contribution/maintenance has already happened by way of testing/patching, and there is reasonable trust demonstrated to "hand the keys" 
 over to a repository.
 
-Currently, the request mechanism is [contact Joshua on IRC](/articles/contributing/getting-involved/en). It is far easier to grant access to active community members than those unknown to the project.
+Currently, the request mechanism is [contact Solus Staff on Matrix](/articles/contributing/getting-involved/en). It is far easier to grant access to active community members than those unknown to the project.
 
 Finally, note that the management reserve the right to revoke access at any time, in order to preserve project safety and integrity.


### PR DESCRIPTION
## Description

Move from IRC to Matrix

- Change channel listings to Matrix
- Slight rewording in the paragraph introducing Matrix
- Change "IRC" -> "Matrix" throughout
- Change "channel" -> "room" throughout
- Change "Joshua" -> "Solus Staff" in process for requesting push access

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
