### PR TITLE
Change straggling IRC references to Matrix

### DIFF
--- a/docs/packaging/procedures/maintainership.md
+++ b/docs/packaging/procedures/maintainership.md
@@ -34,11 +34,11 @@ Maintainers are free to [update a package](/docs/packaging/updating-an-existing-
 
 ### Non-maintainers
 
-If a package is actively maintained, modifications should not occur and the individual should exercise patience when it comes to the updating of software. In some cases, a maintainer may intentionally be holding back a package, or has simply not updated yet. If pertinent, the individual should file a [package update request](/docs/packaging/procedures/request-a-package-update). Alternatively, the individual can reach the maintainers or the Core Team on IRC and ask permission to update the package. It is also possible to submit a patch and attach a message to it clarifying the intention of updating the package, although this is a special case reserved to e.g. security updates and the patch is likely to be rejected.
+If a package is actively maintained, modifications should not occur and the individual should exercise patience when it comes to the updating of software. In some cases, a maintainer may intentionally be holding back a package, or has simply not updated yet. If pertinent, the individual should file a [package update request](/docs/packaging/procedures/request-a-package-update). Alternatively, the individual can reach the maintainers or the Core Team on Matrix and ask permission to update the package. It is also possible to submit a patch and attach a message to it clarifying the intention of updating the package, although this is a special case reserved to e.g. security updates and the patch is likely to be rejected.
 
 ## Template
 
-Presented here is the `MAINTAINERS.md` file. This file must be provided verbatim alongside the other patch contents, and filled in with the maintainers' personal information. An IRC contact is optional but recommended, but an e-mail address is mandatory. Similar to the `.solus/packager` file used for packaging, the maintainers listed in `MAINTAINERS.md` must use their real first and last name(s) for accountability purposes.
+Presented here is the `MAINTAINERS.md` file. This file must be provided verbatim alongside the other patch contents, and filled in with the maintainers' personal information. An Matrix contact is optional but recommended, but an e-mail address is mandatory. Similar to the `.solus/packager` file used for packaging, the maintainers listed in `MAINTAINERS.md` must use their real first and last name(s) for accountability purposes.
 
 The contact information section is a YAML list. If needed, more elements may be added, each per maintainer. Do not edit the file in any other way, including spacing, except *Name*, *Surname* and *REPLACEME* placeholders.
 

--- a/docs/packaging/procedures/release-processes.md
+++ b/docs/packaging/procedures/release-processes.md
@@ -26,7 +26,7 @@ Minor syncs during the week, and correctional syncs shortly after the Friday-syn
 
 ## Package deprecation
 
-Under rare circumstances a package may need to be deprecated or even renamed. Packagers owning these changes must first communicate the need to ensure a coordinated deprecation. Raise the issue on the dev portal, or speak with the core team on IRC to ensure this is implemented correctly.
+Under rare circumstances a package may need to be deprecated or even renamed. Packagers owning these changes must first communicate the need to ensure a coordinated deprecation. Raise the issue on the dev portal, or speak with the core team on Matrix to ensure this is implemented correctly.
 
 Deprecated packages will remove themselves from the users systems as the first operation in an update or package install using the package manager, once marked as `Obsolete` in the index.
 

--- a/docs/packaging/submitting-a-package.md
+++ b/docs/packaging/submitting-a-package.md
@@ -37,7 +37,7 @@ Prior to submitting a patch, please ensure you are checking the following:
 
 Please refrain from submitting a patch for the following instances:
 
-- For a package that is yet to be accepted for inclusion by a member of the Triage Team. We welcome you to politely reach out via the package request task or [IRC](/docs/user/contributing/getting-involved) if you deem the review of the request to be time-sensitive in nature.
+- For a package that is yet to be accepted for inclusion by a member of the Triage Team. We welcome you to politely reach out via the package request task or [Matrix](/docs/user/contributing/getting-involved#matrix-chat) if you deem the review of the request to be time-sensitive in nature.
 - If your patch is a Work In Progress / WIP. Completed patches or patches which have a request for comments are accepted, however for request for comments please ensure your patch title contains `[RFC]`. WIP patches just clutter Differential and make patch review by the team more time consuming and introduces unnecessary work.
 
 ## Setting up Arcanist
@@ -122,6 +122,6 @@ Pushing changes is not possible unless you have maintainer access. The same is a
 To request maintainer rights for a repository, it is expected that some level of contribution/maintenance has already happened by way of testing/patching, and there is reasonable trust demonstrated to "hand the keys" 
 over to a repository.
 
-Currently, the request mechanism is [contact Joshua on IRC](/docs/user/contributing/getting-involved). It is far easier to grant access to active community members than those unknown to the project.
+Currently, the request mechanism is [contact Solus Staff on Matrix](/docs/user/contributing/getting-involved#matrix-chat)
 
 Finally, note that the management reserve the right to revoke access at any time, in order to preserve project safety and integrity.

--- a/docs/user/intro.md
+++ b/docs/user/intro.md
@@ -58,6 +58,6 @@ If you are a Redditor, our subreddit fulfills a similar purpose to the forums.
 
 If you are having issues with your Solus system or one of our software packages not working as expected, you might consider filing a bug report on our Dev Tracker.
 
-**IRC**
+**Matrix**
 
-Last, but not least, we maintain an active presence on the [Libera IRC Network](https://libera.chat). Sign on and head over to `#solus` to get started.
+Last, but not least, we maintain an active presence on [Matrix](https://matrix.org). Sign up and head over to [`#solus:matrix.org`](https://matrix.to/#/#solus:matrix.org)` to get started. Read more about Solus on Matrix [here.](/docs/user/contributing/getting-involved.md#matrix-chat)


### PR DESCRIPTION
## Description

Remove some more IRC references in favor of Matrix

### Submitter Checklist

- [x] Updated the "lastmod" portion at the top of any modified Markdown files.
- [x] Squashed commits with `git rebase -i` (if needed)
