### PR TITLE
Organize "Container" topics

### DIFF
--- a/docs/user/software/development/containers.md
+++ b/docs/user/software/development/containers.md
@@ -1,0 +1,25 @@
+# Containers
+
+Containers are a popular method to run and configure applications in a confined environment without directly installing the application and all it's dependencies. Solus provides the following container technologies: 
+
+## Docker
+
+Docker is a container engine developed by Docker Inc. Solus provides the command line utility `docker` to run and manage docker containers.
+
+A wide variety of applications are available through the official container registry [Docker Hub](https://hub.docker.com/search?q=)
+
+- Install the docker engine by running `sudo eopkg it docker` (you may also want to install `docker-compose`)
+- Test your installation with `sudo docker run hello-world`
+- Optional: For sudo-less docker, run `sudo usermod -aG docker $USER`. You must restart for this change to take effect
+- Optional: Allow the docker daemon to start automatically at system startup `sudo systemctl enable docker`
+- Refer to the official [Docker Docs](https://docs.docker.com/) for further topics
+
+## Podman
+
+Podman is a container manager by Red Hat. Podman's main advantage is the capability of running containers without root permissions, thus limiting the attack surface of the host system. Assuming an attacker will be able to escape a compromised container, they won't have full control of the machine.
+
+Podman's command line interface is 100% compatible with Docker, to the point it's possible to replace the `docker` command with `podman` without any subsequent errors.
+
+- Install Podman by running `sudo eopkg it podman`
+- Optionally, add `alias docker=podman` to your initial shell script, should you want to replace Docker with Podman while retaining your typing habits
+- Refer to the official [Podman website](https://podman.io/) for more documentation

--- a/docs/user/software/development/web.md
+++ b/docs/user/software/development/web.md
@@ -137,14 +137,3 @@ sudo systemctl stop nginx   # To stop nginx.
 
 More details about `systemctl` are available [at this address](https://www.freedesktop.org/software/systemd/man/systemctl.html).
 
-# Container Management
-
-## Vagrant
-
-Vagrant is a tool for building complete development environments. You can use providers listed below with Vagrant, which itself is installable via the `vagrant` package.
-
-### Providers
-
-- **Docker:** You can use Docker as a provider for Vagrant. You can install Docker via the `docker` package.
-
-- **VirtualBox:** You can use VirtualBox as a provider by following the "Solus As Host" instructions [here](/docs/user/software/virtualization/virtualbox#solus-as-host).


### PR DESCRIPTION
- Create a Containers page, with basic docker steps
- Remove Vagrant section [here](https://help.getsol.us/docs/user/software/development/web#vagrant). Package is deprecated. Vagrant provider virtualbox already has it's own page, docker now covered elsewhere

Resolves #262 

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
