### PR TITLE
Move arcanist setup, explain dev tracker

### DIFF
--- a/docs/packaging/index.md
+++ b/docs/packaging/index.md
@@ -43,6 +43,25 @@ Additonally, we need a few more tools to carry out the packaging process:
 sudo eopkg it git arcanist solbuild solbuild-config-unstable
 ```
 
+## Setting up a Dev Tracker Account
+
+The [Solus Dev Tracker](https://dev.getsol.us) is where all packaging patches are submitted and reviewed. It runs [Phabricator](https://www.phacility.com/phabricator/), and we use `arcanist` to submit patches directly from the command line.
+
+To submit patches to  you will need an acount. [Register a new account](https://dev.getsol.us/auth/start/) with your email address, or log in with a Github account. 
+
+### Setting up Arcanist
+
+In three easy steps, you can set up arcanist for the first time:
+
+```bash
+sudo eopkg it arcanist
+arc set-config default https://dev.getsol.us
+arc install-certificate
+```
+
+On the third step you will be given a unique link to log into the Dev Tracker, to create a `Conduit API Token`. This
+token will be used to allow the CLI `arc` utility to communicate with the Dev Tracker.
+
 ## Setting Up solbuild
 
 The `solbuild` tool must first be initialized with a base image. All builds thereafter will use this as a base, and construct a temporary overlay root to save on time and disk space in builds.

--- a/docs/packaging/index.md
+++ b/docs/packaging/index.md
@@ -47,7 +47,7 @@ sudo eopkg it git arcanist solbuild solbuild-config-unstable
 
 The [Solus Dev Tracker](https://dev.getsol.us) is where all packaging patches are submitted and reviewed. It runs [Phabricator](https://www.phacility.com/phabricator/), and we use `arcanist` to submit patches directly from the command line.
 
-To submit patches to  you will need an acount. [Register a new account](https://dev.getsol.us/auth/start/) with your email address, or log in with a Github account. 
+To submit patches to you will need an acount. [Register a new account](https://dev.getsol.us/auth/start/) with your email address, or log in with a Github account. 
 
 ### Setting up Arcanist
 

--- a/docs/packaging/procedures/release-processes.md
+++ b/docs/packaging/procedures/release-processes.md
@@ -25,7 +25,7 @@ Minor syncs during the week, and correctional syncs shortly after the Friday-syn
 
 ## Package deprecation
 
-Under rare circumstances a package may need to be deprecated or even renamed. Packagers owning these changes must first communicate the need to ensure a coordinated deprecation. Raise the issue on the dev portal, or speak with the core team on Matrix to ensure this is implemented correctly.
+Under rare circumstances a package may need to be deprecated or even renamed. Packagers owning these changes must first communicate the need to ensure a coordinated deprecation. Raise the issue on the Dev Tracker, or speak with the core team on Matrix to ensure this is implemented correctly.
 
 Deprecated packages will remove themselves from the users systems as the first operation in an update or package install using the package manager, once marked as `Obsolete` in the index.
 

--- a/docs/packaging/submitting-a-package.md
+++ b/docs/packaging/submitting-a-package.md
@@ -25,7 +25,7 @@ include ../Makefile.common
 Lastly, many package builds may result in the generation of an ABI report. These files start with `abi_*` and must also
 be included, as they allow simple tracking of changes to symbols and dependencies.
 
-For all patch submissions you must be using the `arcanist` utility to communicate with the [Solus Developer Portal](https://dev.getsol.us/)
+For all patch submissions you must be using the `arcanist` utility to communicate with the [Solus Dev Tracker](https://dev.getsol.us/)
 
 ## Prior to Patch Submission
 
@@ -38,19 +38,6 @@ Please refrain from submitting a patch for the following instances:
 
 - For a package that is yet to be accepted for inclusion by a member of the Triage Team. We welcome you to politely reach out via the package request task or [Matrix](/docs/user/contributing/getting-involved#matrix-chat) if you deem the review of the request to be time-sensitive in nature.
 - If your patch is a Work In Progress / WIP. Completed patches or patches which have a request for comments are accepted, however for request for comments please ensure your patch title contains `[RFC]`. WIP patches just clutter Differential and make patch review by the team more time consuming and introduces unnecessary work.
-
-## Setting up Arcanist
-
-In three easy steps, you can set up arcanist for the first time:
-
-```bash
-sudo eopkg it arcanist
-arc set-config default https://dev.getsol.us
-arc install-certificate
-```
-
-On the third step you will be given a unique link to log into the Developer Portal, to create a `Conduit API Token`. This
-token will be used to allow the CLI `arc` utility to communicate with Phabricator.
 
 ## Creating the patch
 
@@ -76,12 +63,12 @@ installed it, it's time to commit your changes with `git commit`.
 Make sure you provide a meaningful summary and a separate body to your commit message. For more information
 on suitable commit messages, please check the [tooling central documentation](https://github.com/solus-project/tooling-central/blob/master/README.rst#using-git).
 
-- If you want to link this patch to an issue on the Developer portal, simply mention it in your commit message: `The inclusion of <somepackage> fixes T1234`
+- If you want to link this patch to an issue on the Dev Tracker, simply mention it in your commit message: `The inclusion of <somepackage> fixes T1234`
 - If you need a change to depend on another change, mention it in the commit message too: `Depends on D5`
 
 ### Submitting for Review
 
-Now you have your git commit, it's time to send it to us for review. Using the CLI again, simply issue: `arc diff`
+Now you have your git commit, it's time to send it to us for review using `arcanist`. Using the CLI again, simply issue: `arc diff`
 
 A new editor session will open, where you can provide additional details. Note that the default reviewer will be assigned after you submit, so it is not necessary to specify anyone here. If you are updating an existing package, please be sure to include a summarized changelog (or a link to the changelog provided upstream) and a test plan indicating that you've installed and run the package. Once you're finished, save and exit the editor (`CTRL+O` + `CTRL+X` for nano), and the patch will then be uploaded. You'll be presented with the Differential URL, and a review will happen as soon as possible.
 

--- a/docs/user/contributing/getting-involved.md
+++ b/docs/user/contributing/getting-involved.md
@@ -63,7 +63,7 @@ We're always looking to improve our systems, especially when they're not functio
 - [Budgie Desktop](https://github.com/buddiesofbudgie/budgie-desktop/issues)
   Budgie Desktop issues are filed in the buddiesofbudgie repo on github.
 
-- [Developer Portal](https://dev.getsol.us)
+- [Dev Tracker](https://dev.getsol.us)
   Most bug reports about Solus itself, and its packages, should be filed here.
 
 - [Solus Github Repos](https://github.com/getsolus)


### PR DESCRIPTION
## Description

- Create new section in "Preparing for Packaging" introducing Dev Tracker and account requirement 
- Move the "Setting up Arcanist" section out of "Submitting a Package" and under the new Dev Tracker section
- Updated various versions of "dev portal, developer portal" to "Dev Tracker"

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
