### PR TITLE
Standardize on "Solus Staff"

### DIFF
--- a/docs/packaging/procedures/maintainership.md
+++ b/docs/packaging/procedures/maintainership.md
@@ -15,13 +15,13 @@ Each new package which is going to land in the Solus repository must have one or
 - Ensure the [packaging file](/docs/packaging/package.yml) adheres to the Solus [standards](/docs/packaging/packaging-practices)
 - Ensure the application or library is consistent with the Operating System aesthetics, file system conventions and the Solus philosophy in general
 
-On the Solus side however, the community must not forget that maintainers are volunteers, which may or may not have a technical background. More experiencied users are to engage newcoming maintainers in a welcoming manner, e.g. by listing their errors and inviting them to fix them. (More on this in the [community guidelines](/docs/user/contributing/community-guidelines#development--issue-trackers))
+On the Solus side however, the community must not forget that maintainers are volunteers, which may or may not have a technical background. More experienced users are to engage new maintainers in a welcoming manner, e.g. by listing their errors and inviting them to fix them. (More on this in the [community guidelines](/docs/user/contributing/community-guidelines#development--issue-trackers))
 
-The Core Team has the right to enforce certain practices, even when in contrast with maintainers' vision. It also has the right to ultimately accept or reject a patch.
+The Solus Staff have the right to enforce certain practices, even when in contrast with maintainers' vision. It also has the right to ultimately accept or reject a patch.
 
 ## Stepping in
 
-To officially step in as the maintainer of a package, a `MAINTAINERS.md` file must be provided for accepted packages that are not yet included in the repository, or if the package predates the policy of requiring one. Instead, if a previously maintained package is marked by the Solus team as needing a new maintainer, the `MAINTAINERS.md` file must be updated.
+To officially step in as the maintainer of a package, a `MAINTAINERS.md` file must be provided for accepted packages that are not yet included in the repository, or if the package predates the policy of requiring one. Instead, if a previously maintained package is marked by Solus Staff as needing a new maintainer, the `MAINTAINERS.md` file must be updated.
 
 ## Updating a maintained package
 
@@ -29,11 +29,11 @@ The procedure varies depending on whether or not the individual is the maintaine
 
 ### Maintainers
 
-Maintainers are free to [update a package](/docs/packaging/updating-an-existing-package) at their will, unless otherwise indicated by the Core Team.
+Maintainers are free to [update a package](/docs/packaging/updating-an-existing-package) at their will, unless otherwise indicated by Solus Staff.
 
 ### Non-maintainers
 
-If a package is actively maintained, modifications should not occur and the individual should exercise patience when it comes to the updating of software. In some cases, a maintainer may intentionally be holding back a package, or has simply not updated yet. If pertinent, the individual should file a [package update request](/docs/packaging/procedures/request-a-package-update). Alternatively, the individual can reach the maintainers or the Core Team on Matrix and ask permission to update the package. It is also possible to submit a patch and attach a message to it clarifying the intention of updating the package, although this is a special case reserved to e.g. security updates.
+If a package is actively maintained, modifications should not occur and the individual should exercise patience when it comes to the updating of software. In some cases, a maintainer may intentionally be holding back a package, or has simply not updated yet. If pertinent, the individual should file a [package update request](/docs/packaging/procedures/request-a-package-update). Alternatively, the individual can reach the maintainers or Solus Staff on Matrix and ask permission to update the package. It is also possible to submit a patch and attach a message to it clarifying the intention of updating the package, although this is a special case reserved to e.g. security updates.
 
 ## Template
 
@@ -42,7 +42,7 @@ Presented here is the `MAINTAINERS.md` file. This file must be provided verbatim
 The contact information section is a YAML list. If needed, more elements may be added, each per maintainer. Do not edit the file in any other way, including spacing, except _Name_, _Surname_ and _REPLACEME_ placeholders.
 
 ```
-This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
+This file is used to indicate primary maintainership for this package. A package may list more than one maintainer to avoid bus factor issues. People on this list may be considered “subject-matter experts”. Please note that Solus Staff may need to perform necessary rebuilds, upgrades, or security fixes as part of the normal maintenance of the Solus package repository. If you believe this package requires an update, follow documentation from https://help.getsol.us/docs/packaging/procedures/request-a-package-update. In the event that this package becomes insufficiently maintained, the Solus Staff reserves the right to request a new maintainer, or deprecate and remove this package from the repository entirely.
 
 - Name Surname
   - Matrix: REPLACEME

--- a/docs/packaging/procedures/package-inclusion.md
+++ b/docs/packaging/procedures/package-inclusion.md
@@ -32,7 +32,7 @@ This policy sets forth the criteria for a package to be accepted for inclusion i
 
 ### Stack Complexity
 
-- Certain requests may tick all the boxes, but introduce a level of complexity or require a level of engagement not possible to balance for the packaging team. Under certain situations, a request will be frozen until it has a dedicated maintainer.
+- Certain requests may tick all the boxes, but introduce a level of complexity or require a level of engagement not possible to balance for Solus Staff. Under certain situations, a request will be frozen until it has a dedicated maintainer.
 - This extends to requests for full desktop environments. However, this does not extend to minor components like drop-in window managers or panels separate of a dependent stack (i.e. Awesome WM, tint2, etc.)
 
 ### Value Add
@@ -45,4 +45,4 @@ This policy sets forth the criteria for a package to be accepted for inclusion i
 
 ## Rejection
 
-Solus team members reserve the right to permanently reject a package request without the need for further discussion once the rejection is issued. The limited time of contributors should be considered and respected, instead of dragging out and 'necromancing' old issues in a vain attempt to force inclusion of previously rejected software. In the event of any policy change, existing/expired package requests will NOT be reevaluated under new criteria as this would lead to an exponential growth in work upon every policy change, and is physically impossible to handle for a project of _any_ size.
+Solus Staff members reserve the right to permanently reject a package request without the need for further discussion once the rejection is issued. The limited time of contributors should be considered and respected, instead of dragging out and 'necromancing' old issues in a vain attempt to force inclusion of previously rejected software. In the event of any policy change, existing/expired package requests will NOT be reevaluated under new criteria as this would lead to an exponential growth in work upon every policy change, and is physically impossible to handle for a project of _any_ size.

--- a/docs/packaging/procedures/release-processes.md
+++ b/docs/packaging/procedures/release-processes.md
@@ -25,7 +25,7 @@ Minor syncs during the week, and correctional syncs shortly after the Friday-syn
 
 ## Package deprecation
 
-Under rare circumstances a package may need to be deprecated or even renamed. Packagers owning these changes must first communicate the need to ensure a coordinated deprecation. Raise the issue on the Dev Tracker, or speak with the core team on Matrix to ensure this is implemented correctly.
+Under rare circumstances a package may need to be deprecated or even renamed. Packagers owning these changes must first communicate the need to ensure a coordinated deprecation. Raise the issue on the Dev Tracker, or speak with Solus Staff on Matrix to ensure this is implemented correctly.
 
 Deprecated packages will remove themselves from the users systems as the first operation in an update or package install using the package manager, once marked as `Obsolete` in the index.
 

--- a/docs/packaging/submitting-a-package.md
+++ b/docs/packaging/submitting-a-package.md
@@ -36,8 +36,8 @@ Prior to submitting a patch, please ensure you are checking the following:
 
 Please refrain from submitting a patch for the following instances:
 
-- For a package that is yet to be accepted for inclusion by a member of the Triage Team. We welcome you to politely reach out via the package request task or [Matrix](/docs/user/contributing/getting-involved#matrix-chat) if you deem the review of the request to be time-sensitive in nature.
-- If your patch is a Work In Progress / WIP. Completed patches or patches which have a request for comments are accepted, however for request for comments please ensure your patch title contains `[RFC]`. WIP patches just clutter Differential and make patch review by the team more time consuming and introduces unnecessary work.
+- For a package that is yet to be accepted for inclusion by a member of the Solus Staff team. We welcome you to politely reach out via the package request task or [Matrix](/docs/user/contributing/getting-involved#matrix-chat) if you deem the review of the request to be time-sensitive in nature.
+- If your patch is a Work In Progress / WIP. Completed patches or patches which have a request for comments are accepted, however for request for comments please ensure your patch title contains `[RFC]`. WIP patches just clutter Differential and make patch review by Solus Staff more time consuming and introduces unnecessary work.
 
 ## Creating the patch
 

--- a/docs/user/contributing/community-guidelines.md
+++ b/docs/user/contributing/community-guidelines.md
@@ -7,7 +7,7 @@ summary: Community Guidelines
 
 The Solus Project enforces a set of community guidelines to maintain a family-friendly, respectful, and professional environment.
 
-Our guidelines apply to all services offered or used by the project, in addition to any terms of service of third-party services used by the project. The Solus Team reserves the right to either ban or terminate access, on a temporary or permanent basis, to members of the community which are found to be violating our guidelines.
+Our guidelines apply to all services offered or used by the project, in addition to any terms of service of third-party services used by the project. Solus Staff reserves the right to either ban or terminate access, on a temporary or permanent basis, to members of the community which are found to be violating our guidelines.
 
 ## General Guidelines
 
@@ -24,7 +24,7 @@ The project condemns any and all forms of harassment. Harassment by individuals 
 
 This extends to any and all events / venues sponsored or otherwise supported by the project. Harassment in such events or venues will result in the permanent banning of such individuals from future events and if necessary, the immediate removal of such individuals from any current events / venues.
 
-You are encouraged to reach out to a member of the Solus team should you be harassed by any member of our community so such matters may be addressed immediately.
+You are encouraged to reach out to a member of the Solus Staff should you be harassed by any member of our community so such matters may be addressed immediately.
 
 ### Language
 
@@ -39,7 +39,7 @@ Members of the community are expected to engage in a manner which is respectful 
   - Political affiliation
 - Sexual or otherwise lewd in nature
 
-Profane language which is not derogatory, hateful, or sexual in nature may be allowed in specific off-topic rooms or other locations permitted by the project. However, the Solus Moderation team reserves the right to request the immediate ceasing of the use of such language by any individual if it is deemed to be derogatory, hateful, sexual, or in a manner which is otherwise distasteful.
+Profane language which is not derogatory, hateful, or sexual in nature may be allowed in specific off-topic rooms or other locations permitted by the project. However, the Solus Staff moderation team reserves the right to request the immediate ceasing of the use of such language by any individual if it is deemed to be derogatory, hateful, sexual, or in a manner which is otherwise distasteful.
 
 ### Media Sharing
 
@@ -49,7 +49,7 @@ Members of the community shall not link / share media which is illegal, pornogra
 
 Members of the community should attempt to observe topic guidance when participating in various services offered or used by the project, such as:
 
-- Ensuring support-related rooms / mediums remain free of development and off-topic discussions to maximize the community and team’s ability to respond and address issues or support requests.
+- Ensuring support-related rooms / mediums remain free of development and off-topic discussions to maximize the community and Solus Staff’s ability to respond and address issues or support requests.
 - Ensuring development rooms / mediums remain free of off-topic discussions which are not relevant to the development or progression of various development items relating to Solus.
 - Ensuring off-topic rooms / mediums remain free of heated discussions of polarizing issues or current events in order to keep these spaces inviting and enjoyable.
 
@@ -75,12 +75,12 @@ Solus utilizes a multitude of development and issue trackers to facilitate the d
 Members of the community are expected to:
 
 - Maintain on-topic discussions as relevant to each individual task
-- Not engage in disruptive behavior such as the modification of tasks or task information which are not owned or assigned to the user. Please leave the general maintenance of tasks or requesting of specific information to individuals which are assigned to the task, or members of the Triage Team, Global Maintainers, or Core Team.
+- Not engage in disruptive behavior such as the modification of tasks or task information which are not owned or assigned to the user. Please leave the general maintenance of tasks or requesting of specific information to individuals which are assigned to the task, or Solus Staff
 - Refrain from using the Development Tracker for general support queries, such as (but not limited to): installation assistance, package installation assistance, etc.
 
 Members of the community should remain mindful that all contributors to the project do so on a voluntary basis, in their free time, and should refrain from making demands or engaging in behavior which is not respectful.
 
-The Solus team reserves the rights to:
+Solus Staff reserves the rights to:
 
 - Close or lock tasks on a temporary or permanent basis
 - Disable the account of individuals which violate either general guidelines or “Development / Issue Trackers”-specific guidelines.

--- a/docs/user/contributing/getting-involved.md
+++ b/docs/user/contributing/getting-involved.md
@@ -44,8 +44,8 @@ Solus is funded through our [Open Collective](https://opencollective.com/getsolu
 
 1. Offset virtual and physical infrastructure / hardware, ranging from datacenter co-location to providing repository mirrors and hardware upgrades for faster builds.
 2. Enable part-time and eventually full-time development by one or more developers (e.g. myself and Beatrice).
-3. Subsidize or pay in full necessary hardware for the Solus team and active contributors.
-4. Provide opportunities to finance specific approved works, such as various features, fixes, or rewrites that the Team would want to be done in a timely manner, by individuals in the our community that are well-known for high-quality contributions. These opportunities would be provided on a case-by-case basis with direct communication and engagement between all the Team and individual.
+3. Subsidize or pay in full necessary hardware for Solus Staff and active contributors.
+4. Provide opportunities to finance specific approved works, such as various features, fixes, or rewrites that the Solus Staff would want to be done in a timely manner, by individuals in the our community that are well-known for high-quality contributions. These opportunities would be provided on a case-by-case basis with direct communication and engagement between Solus Staff and the individual.
 
 ## Improving Documentation
 


### PR DESCRIPTION
Replace variations of "Solus Team", "Core Team", "Packaging Team" with just "Solus Staff"


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
