### PR TITLE
docs/packaging: Remove arcanist package & use shorter GH signup URL

### DIFF
--- a/docs/packaging/index.md
+++ b/docs/packaging/index.md
@@ -48,7 +48,8 @@ sudo eopkg it git solbuild solbuild-config-unstable
 ```
 
 ## Setting up a GitHub account
-The solus source repositories for the package repository currently reside on [github.com/solus-packages](https://github.com/solus-packages). You will need a GitHub account to submit patches and file issues. You can create a GitHub account [here](https://github.com/signup?ref_cta=Sign+up&ref_loc=header+logged+out&ref_page=%2F&source=header-home).
+
+The solus source repositories for the package repository currently reside on [github.com/solus-packages](https://github.com/solus-packages). You will need a GitHub account to submit patches and file issues. You can create a GitHub account [here](https://github.com/signup).
 
 ## Setting Up solbuild
 

--- a/docs/packaging/index.md
+++ b/docs/packaging/index.md
@@ -44,7 +44,7 @@ Additionally, we need a few more tools to carry out the packaging process:
 - `solbuild-config-unstable` sets up solbuild for working with the `unstable` repository
 
 ```bash
-sudo eopkg it git arcanist solbuild solbuild-config-unstable
+sudo eopkg it git solbuild solbuild-config-unstable
 ```
 
 ## Setting up a GitHub account


### PR DESCRIPTION
## Description

Removes arcanist from required package list & uses shorter GitHub signup URL

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
