### PR TITLE
General update for phab -> GH migration

### DIFF
--- a/docs/packaging/procedures/request-a-package-update.md
+++ b/docs/packaging/procedures/request-a-package-update.md
@@ -1,11 +1,11 @@
 ---
 title: Requesting a Package Update
-summary: Boohoo, your favourite package is outdated!
+summary: Boohoo, your favorite package is outdated!
 ---
 
 # Requesting A Package Update
 
-Packages updates are typically provided by community or dedicated package maintainers, however if we are not shipping the latest stable release of a package, you can let us know using our [Task Tracker](https://dev.getsol.us/)
+Packages updates are typically provided by community or dedicated package maintainers, however if we are not shipping the latest stable release of a package, you can let us know using our [Issue Tracker](https://issues.getsol.us/)
 
 **Please look to see if an update request has already been filed for the software or library you require**.
 
@@ -20,4 +20,4 @@ Please provide the following information:
 - master.zip files **are not permitted**. We require versioned tarballs, for example: "1.2.3.tar.gz".
 - Use the tag **Software** for tagging your update request
 
-Please put this information into a new [task](https://dev.getsol.us/maniphest/task/edit/form/1/)
+Please put this information into a new [issue](https://github.com/getsolus/packages/issues/new?assignees=&labels=Package+Request&projects=&template=request-package-update.yaml)

--- a/docs/packaging/procedures/request-a-package.md
+++ b/docs/packaging/procedures/request-a-package.md
@@ -21,4 +21,4 @@ Please provide as much of the following information as possible:
 - Link to source tarball/zip file
 - master.zip files **are not permitted**. We require versioned tarballs, for example: "1.2.3.tar.gz" or "packagename-1.2.3".
 
-Please put this information into a new [task](https://dev.getsol.us/maniphest/task/edit/form/4/).
+Please put this information into a new [issue](https://github.com/getsolus/packages/issues/new?assignees=&labels=Package+Request%2CPriority%3A+Wishlist&projects=&template=request-new-package.yml&title=What%27s+the+package+name%3F).

--- a/docs/packaging/submitting-a-package.md
+++ b/docs/packaging/submitting-a-package.md
@@ -25,8 +25,6 @@ include ../Makefile.common
 Lastly, many package builds may result in the generation of an ABI report. These files start with `abi_*` and must also
 be included, as they allow simple tracking of changes to symbols and dependencies.
 
-For all patch submissions you must be using the `arcanist` utility to communicate with the [Solus Dev Tracker](https://dev.getsol.us/)
-
 ## Prior to Patch Submission
 
 Prior to submitting a patch, please ensure you are checking the following:
@@ -45,7 +43,7 @@ Please refrain from submitting a patch for the following instances:
 
 #### Creating a new branch (optional)
 
-This is optional but recommended. This will allow you to more easily seperate your work from an new changes made to the package repository which will allow you to more easily rebase any changes if needed. Create a new branch and switch to it by running `git checkout -b my-branch`
+This is optional but recommended. This will allow you to more easily separate your work from an new changes made to the package repository which will allow you to more easily rebase any changes if needed. Create a new branch and switch to it by running `git checkout -b my-branch`
 
 :::tip
 - You can checkout the master branch by running `git checkout master`, and switch back to your branch by running `git checkout my-branch`
@@ -73,8 +71,8 @@ installed it, it's time to commit your changes with `git commit`.
 Make sure you provide a meaningful summary and a separate body to your commit message. For more information
 on suitable commit messages, please check the [tooling central documentation](https://github.com/solus-project/tooling-central/blob/master/README.rst#using-git).
 
-- If you want to link this patch to an issue on the Dev Tracker, simply mention it in your commit message: `The inclusion of <somepackage> fixes T1234`
-- If you need a change to depend on another change, mention it in the commit message too: `Depends on D5`
+- If you want to link this patch to an issue on the Dev Tracker, simply mention it in your commit message: `The inclusion of <somepackage> fixes #1234`
+- If you need a change to depend on another change, mention it in the commit message too: `Depends on #123`
 
 ### Submitting for Review
 
@@ -84,7 +82,7 @@ You will first need to fork the repository either from the GitHub web interface.
 
 Next change your push url to the one that matches your fork. For example
 
-If you forked github.com/solus-packages/nano. It would be forked to github.com/mygithubaccount/nano. You can then set the push url to
+If you forked `github.com/solus-packages/nano`, it would be forked to `github.com/mygithubaccount/nano`. You can then set the push url to
 
 `git remote set-url --push origin https://github.com/mygithubaccount/nano`
 

--- a/docs/packaging/updating-an-existing-package.md
+++ b/docs/packaging/updating-an-existing-package.md
@@ -7,7 +7,7 @@ summary: Updating an Existing Package
 
 This article will go over updating a package that is already in the Solus git repository.
 
-The instructions below assume you have cloned the package's repository using the https link provided on the respective git page, [for example nano](https://dev.getsol.us/source/nano/). The process for submitting an updated package is the same as if it is a new package. Follow the steps [here](/docs/packaging/submitting-a-package).
+The instructions below assume you have cloned the package's repository using the https link provided on the respective git page, [for example nano](https://github.com/solus-packages/nano). The process for submitting an updated package is the same as if it is a new package. Follow the steps [here](/docs/packaging/submitting-a-package).
 
 ## Bumping a package
 

--- a/docs/user/contributing/community-guidelines.md
+++ b/docs/user/contributing/community-guidelines.md
@@ -67,10 +67,10 @@ The below mentioned guidelines apply to individual services provided or used by 
 
 ### Development / Issue Trackers
 
-Solus utilizes a multitude of development and issue trackers to facilitate the development of various items in our project and to address issues raised by our community through tasks / issue reports. These development trackers include, but are not limited to:
+Solus utilizes a number of development and issue trackers to facilitate the development of various projects, and to address issues raised by our community through tasks / issue reports. These development trackers include, but are not limited to:
 
-- Our self-hosted development tracker (Phabricator) at https://dev.getsol.us
-- All issue trackers utilized by the project across repositories hosted in our GitHub organizations
+- The main Solus Github Issue Tracker at `issues.getsol.us`
+- Other GitHub issue trackers found in other Solus repositories under the `getsolus` organization.
 
 Members of the community are expected to:
 

--- a/docs/user/contributing/getting-involved.md
+++ b/docs/user/contributing/getting-involved.md
@@ -62,14 +62,14 @@ and contribute to the community by packaging software. If you're interested in l
 
 We're always looking to improve our systems, especially when they're not functioning as expected. By reporting bugs, you improve the system not only for you, but for all Solus Project users.
 
-- [Budgie Desktop](https://github.com/buddiesofbudgie/budgie-desktop/issues)
-  Budgie Desktop issues are filed in the buddiesofbudgie repo on github.
-
-- [Dev Tracker](https://dev.getsol.us)
+- [Main Solus GitHub Issue Tracker](https://issues.getsol.us)
   Most bug reports about Solus itself, and its packages, should be filed here.
 
-- [Solus Github Repos](https://github.com/getsolus)
-  Certain parts of Solus, such as the Software Center, have repos on the getsolus repo on github. Check here to see if the system in question is listed. If so, file the bug in the appropriate repo.
+- [Other Solus Github Repos](https://github.com/getsolus)
+  Certain parts of Solus, such as the Software Center, have repos in the `getsolus` organization on GitHub. Check here to see if the system in question is listed. If so, file the bug in the appropriate repo.
+
+- [Budgie Desktop](https://github.com/buddiesofbudgie/budgie-desktop/issues)
+  Budgie Desktop issues are filed in the `buddiesofbudgie` repo on GitHub.
 
 ## Translations
 

--- a/docs/user/intro.md
+++ b/docs/user/intro.md
@@ -52,6 +52,6 @@ Read more about Solus on Matrix [here.](/docs/user/contributing/getting-involved
 
 If you are a Redditor, our subreddit fulfills a similar purpose to the forums.
 
-**[Dev Tracker](https://dev.getsol.us)**
+**[Issue Tracker](https://issues.getsol.us)**
 
 If you are having issues with your Solus system or one of our software packages not working as expected, you might consider filing a bug report on our Dev Tracker.

--- a/docs/user/software/command-line/index.md
+++ b/docs/user/software/command-line/index.md
@@ -127,8 +127,8 @@ FZF_KEYBINDING_FILE=/usr/share/fzf/key-bindings.zsh
 
 ### Installation
 
-Powerline has two components, the plugin system itself ([powerline](https://dev.getsol.us/source/powerline/)) and the
-fonts ([powerline-fonts](https://dev.getsol.us/source/powerline-fonts/)). Both are available in the Software Center or via eopkg in a terminal:
+Powerline has two components, the plugin system itself `powerline` and the
+fonts `powerline-fonts`. Both are available in the Software Center or via `eopkg` in a terminal:
 
 ```bash
 sudo eopkg it powerline powerline-fonts

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -157,9 +157,14 @@ const config = {
                 rel: "me",
               },
               {
-                label: "Dev Tracker",
+                label: "Packages",
                 href: "https://dev.getsol.us",
               },
+              {
+                label: "Issue Tracker",
+                href: "https://issues.getsol.us",
+              },
+              
             ],
           },
         ],

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -39,9 +39,13 @@
     "message": "GitHub",
     "description": "The label of footer link with label=GitHub linking to https://github.com/getsolus"
   },
-  "link.item.label.Dev Tracker": {
-    "message": "Dev Tracker",
-    "description": "The label of footer link with label=Dev Tracker linking to https://dev.getsol.us"
+  "link.item.label.Packages": {
+    "message": "Packages",
+    "description": "The label of footer link with label=Packages linking to https://dev.getsol.us"
+  },
+  "link.item.label.Issue Tracker": {
+    "message": "Issue Tracker",
+    "description": "The label of footer link with label=Issue Tracker linking to https://issues.getsol.us"
   },
   "copyright": {
     "message": "Copyright © 2023 Solus Project. Built with Docusaurus.",


### PR DESCRIPTION
- Generally update references and surrounding word-salad wherever we use dev.getsol.us
- Additionally create references to issues.getsol.us
- Assumptions:
  - `dev.getsol.us` will point to package repos (and eventually, the package monorepo) 
    - AKA "Packages"
  - `issues.getsol.us` will point to a general bug report landing page, not a specific form https://github.com/getsolus/packages/issues/new/choose 
    - AKA "Issue Tracker" or "Main Solus GitHub Issue Tracker" when contrasting with various other GH issue trackers


