### PR TITLE
packaging-practices: make builddeps order more explicit

### DIFF
--- a/docs/packaging/packaging-practices.md
+++ b/docs/packaging/packaging-practices.md
@@ -93,21 +93,22 @@ All new packages or updates to packages should abide by the [SPDX 3.x](https://s
 ## Build dependencies
 
 :::note
-Build dependencies should be listed in the following order in `package.yml`
-pkgconfig dependencies in alphabetical order
-explicitly named dependencies in alphabetical order
+Build dependencies should be ordered according to the following rules in `package.yml`:
+1. `pkgconfig` dependencies before explicitly named dependencies
+2. Each of these two groups in so-called ASCIIbetical order (that is, alphabetical order with all uppercase letters before lowercase letters, and digits/punctuation before letters, [see here](https://en.wikipedia.org/wiki/ASCII#Character_order))
 
 Example:
 <!-- prettier-ignore -->
 ```yaml
 builddeps  :
+    - pkgconfig(MYGUI)
+    - pkgconfig(Qt5Core)
     - pkgconfig(ayatana-appindicator-0.1)
     - pkgconfig(dri)
     - pkgconfig(gtk+-3.0)
-    - pkgconfig(libnotify)
-    - pkgconfig(libpcsclite)
-    - pkgconfig(pango)
-    - pkgconfig(python3)
+    - The-Powder-Toy
+    - abcMIDI
+    - abcm2ps
     - git
     - python-poetry
     - swig


### PR DESCRIPTION
## Description

packaging-practices: make builddeps order more explicit

Mentioning A-Z before a-z, use example showing it in practice

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
