### PR TITLE
One last update for monorepo + go-task

### DIFF
--- a/docs/packaging/creating-a-new-package.md
+++ b/docs/packaging/creating-a-new-package.md
@@ -18,31 +18,11 @@ This PR resolves software request https://github.com/getsolus/packages/issues/12
 
 :::
 
-## Fork the getsolus/packages Repository / Update Your Fork
-
-### Create a Fork
-
-If you had not yet done so already, fork the repo [getsolus/packages](https://github.com/getsolus/packages) using the GitHub web UI or [`gh` cli tool](https://cli.github.com/manual/gh_repo_fork) from the `github-cli` package. It will be forked to `github.com/yourgithubaccount/packages`.
-
-### Update a Fork
-
-If you already have a fork of [getsolus/packages](https://github.com/getsolus/packages) in GitHub, log into GitHub. Make sure you're looking at the `main` branch. Check to see that your fork is up to date with the main repo it was forked from. If your fork indicates it is behind, use the "Sync fork" button to bring it up to date.
-
-## Clone the packages repo / update your clone
-
-### Clone the repo
-
-From within your packaging directory, clone the fork. Then, change to this directory.
-
-```bash
-cd ~/solus-builds
-gh repo clone yourgithubaccount/packages
-cd ~/solus-builds/packages
-```
-
 ### Update an existing clone
 
-If you already have a local clone, you need to bring it up to date. To do this run:
+If you do not have a local clone set up yet, see [Prepare for Packaging](prepare-for-packaging.md#fork-the-getsoluspackages-repository)
+
+Bring your local clone up to date. Run:
 
 ```bash
 cd ~/solus-builds/packages
@@ -73,20 +53,21 @@ You must add a file called `MAINTAINERS.md` using the template in [Maintainershi
 
 You will need a link to the most recent source tarball for this from the software's website.
 
-Create a skeleton `package.yml` file using the script `common/Scripts/yauto.py` and the link for the tarball. For example:
+To create a skeleton `package.yml` file, use the the `go-task new` command
+
+This command takes two arguments, in the following order:
+
+1. package name
+2. Source URL
 
 ```bash
-../common/Scripts/yauto.py https://gitlab.com/OldManProgrammer/unix-tree/-/archive/2.1.1/unix-tree-2.1.1.tar.gz
+go-task new -- tree https://gitlab.com/OldManProgrammer/unix-tree/-/archive/2.1.1/unix-tree-2.1.1.tar.gz
 ```
 
-Consider creating an alias for this script in your `.bashrc` file (or equivalent for your preferred shell).
-
-```bash
-alias fetchYml="$HOME/solus-builds/common/Scripts/yauto.py"
-```
+The `go-task new` command will automatically place the new `package.yml` in the proper directory according the package name, _and will overwrite any existing `package.yml` file at that location_
 
 :::note
-You can, of course, create your `package.yml` file entirely from scratch, but the script will give you a better starting point. We recommend using the script.
+You can, of course, create your `package.yml` file entirely from scratch, but `go-task new` will give you a better starting point. We recommend using the `go-task new` command.
 :::
 
 Now you should have a `package.yml` file that looks something like this:
@@ -113,7 +94,7 @@ install    : |
     %make_install
 ```
 
-The `yauto.py` script has filled many fields for us, but not all of them will be right, and some of them need to be filled in. Refer to the [package.yml page](docs/packaging/package.yml.md) to see how each field should be used.
+The `go-task new` command has filled many fields for us, but not all of them will be right, and some of them need to be filled in. Refer to the [package.yml page](docs/packaging/package.yml.md) to see how each field should be used.
 
 For this example, we need to fix the following:
 
@@ -175,7 +156,7 @@ Check the [changes in your files](git-basics).
 
 Run `git status`. Make sure all the files you changed are staged, and that there are no untracked files. When all is well, run `git commit --cleanup=scissors`.
 
-import GitCommitCleanup from './_git_commit_cleanup.md';
+import GitCommitCleanup from './\_git_commit_cleanup.md';
 
 <GitCommitCleanup/>
 

--- a/docs/packaging/prepare-for-packaging.md
+++ b/docs/packaging/prepare-for-packaging.md
@@ -84,25 +84,17 @@ mkdir ~/solus-builds
 cd solus-builds
 ```
 
-##  Recommended aliases
-Consider creating these aliases in your `.bashrc` file (or equivalent for the zsh or fish shell).
+## Fork the getsolus/packages Repository
 
-The script `common/Scripts/yauto.py` is used to create an initial `package.yml` file for packages that aren't yet in the repository.
+Create your own fork of [getsolus/packages](https://github.com/getsolus/packages) using the GitHub web UI or [`gh` cli tool](https://cli.github.com/manual/gh_repo_fork) from the `github-cli` package. It will be forked to `github.com/yourgithubaccount/packages`.
 
-```bash
-alias fetchYml="$HOME/solus-builds/common/Scripts/yauto.py"
-```
+## Clone Your Forked Package Repository
 
-The script `common/Scripts/epcsearch.py` is used to find packages that satisfy build dependencies.
+Create a local clone of the package repository you just forked
 
 ```bash
-alias epcsearch='~/packaging/common/Scripts/epcsearch.py'
-```
-
-The `yupdate` tool is used when updating packages.
-
-```bash
-alias updatePackage='/usr/share/ypkg/yupdate.py'
+cd ~/solus-builds
+gh repo clone yourgithubaccount/packages
 ```
 
 ## Building Packages

--- a/docs/packaging/update-dev-environment.md
+++ b/docs/packaging/update-dev-environment.md
@@ -6,19 +6,30 @@ sidebar_position: 2
 
 # Update Your Development Environment
 
-## Update the development tools and the system
+Always make sure your development environment and system are up to date before beginning work on a package
 
-Always make sure your development environment and system are up to date before beginning work on a package. First, update the development tools and system
+1. Update your fork of the getsolus/packages Repository.
+2. Update your local clone of your fork.
+3. Update the solbuild base image `sudo solbuild update`
+4. Update the system.
 
-1. Update common
-2. Update the solbuild base image `sudo solbuild update`
-3. Update the system.
+## Update Your Fork of the getsolus/packages Repository
 
-The below assumes your Solus packaging directories are under `~/solus-builds`
+If you already have a fork of [getsolus/packages](https://github.com/getsolus/packages) in GitHub, log into GitHub. Make sure you're looking at the `main` branch. Check to see that your fork is up to date with the main repo it was forked from. If your fork indicates it is behind, use the "Sync fork" button to bring it up to date.
+
+## Update Your Local Clone of Your Fork
+
+If you already have a local clone, you need to bring it up to date. To do so run:
 
 ```bash
-cd ~/solus-builds/common
+cd ~/solus-builds
+git switch main
 git pull
+```
+
+## Update `solbuild` and the System
+
+```bash
 sudo solbuild update
 sudo eopkg up
 ```

--- a/docs/packaging/updating-an-existing-package.md
+++ b/docs/packaging/updating-an-existing-package.md
@@ -19,32 +19,11 @@ This PR resolves software update request https://github.com/getsolus/packages/is
 
 :::
 
+### Update your clone of the packages Repository
 
-## Fork the getsolus/packages Repository / Update Your Fork
+If you do not have a local clone set up yet, see [Prepare for Packaging](prepare-for-packaging.md#fork-the-getsoluspackages-repository)
 
-### Create a Fork
-
-If you had not yet done so already, fork [getsolus/packages](https://github.com/getsolus/packages) using the GitHub web UI or [`gh` cli tool](https://cli.github.com/manual/gh_repo_fork) from the `github-cli` package. It will be forked to `github.com/yourgithubaccount/packages`.
-
-### Update a Fork
-
-If you already have a fork of [getsolus/packages](https://github.com/getsolus/packages) in GitHub, log into GitHub. Make sure you're looking at the `main` branch. Check to see that your fork is up to date with the main repo it was forked from. If your fork indicates it is behind, use the "Sync fork" button to bring it up to date.
-
-## Clone the package repo / update your clone
-
-### Clone the repo
-
-If you do not yet have a clone of your packages repo fork, change to your packaging directory and clone your fork. Then, switch to the directory of the package to update. For example:
-
-```bash
-cd ~/solus-builds
-gh repo clone yourgithubaccount/packages
-cd packages/packages/n/nano
-```
-
-### Update an existing clone
-
-If you already have a local clone, you need to bring it up to date. To do so run:
+Bring your local clone up to date. Run:
 
 ```bash
 cd ~/solus-builds/packages/n/nano
@@ -69,13 +48,9 @@ This can be achieved by doing `go-task bump`, which increments the release numbe
 
 ## Updating a Package
 
-To update the package to a newer version, use the `yupdate` tool. This is located at `/usr/share/ypkg/yupdate.py`. We recommend setting an alias via your `.bashrc`, `.zshrc`, or method appropriate to your shell.
+To update the package to a newer version, use the `go-task update` command.
 
-```bash
-alias updatePackage='/usr/share/ypkg/yupdate.py'
-```
-
-This script takes two arguments, in the following order:
+This command takes two arguments, in the following order:
 
 1. Version
 2. Source URL
@@ -85,7 +60,7 @@ If you're updating the package to a newer version, naturally you would change bo
 Example:
 
 ```bash
-/usr/share/ypkg/yupdate.py 1.0 https://example.com/example-1.0.tar.xz
+go-task update -- 1.0 https://example.com/example-1.0.tar.xz
 ```
 
 ## The `MAINTAINERS.md` File
@@ -105,7 +80,7 @@ Check the [changes in your files](git-basics#check-the-changes-in-your-files).
 
 Run `git status`. Make sure all the files you changed are staged, and that there are no untracked files. When all is well, run `git commit --cleanup=scissors`.
 
-import GitCommitCleanup from './_git_commit_cleanup.md';
+import GitCommitCleanup from './\_git_commit_cleanup.md';
 
 <GitCommitCleanup/>
 


### PR DESCRIPTION
## Description

### Monorepo stuff

The suggested order for the packaging docs is

"prepare for packaging"
"your first package"
"update your dev env"
"creating a new package" or "updating an existing package"

But the "update you dev env" page has old steps referencing a `common` repo separate from the monorepo. Meanwhile, the updated "create new" and "update existing" docs had steps to fork, clone, and update the monorepo.

This PR moves the monorepo setup stuff to "prepare for packaging", and "update you dev env" and removes it from the other two pages.

### Go-task stuff

Use of yauto.py and yupdate.py are replaced with the nicer go-task wrappers.

We can remove the portion explaining the typical aliases. ~~This does leave us with  a single lonely recommended alias in "prepare for packaging"~~ They all have go-task equivalents

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
