### PR TITLE
java: Add note on openjdk-8

### DIFF
--- a/docs/user/software/development/java.md
+++ b/docs/user/software/development/java.md
@@ -9,7 +9,7 @@ Solus includes multiple LTS versions of Java in the repositories. You can instal
 
 :::tip
 
-If you need to install different versions or Java, use alternative installation methods such as [_SDKMAN!_](https://sdkman.io/).
+If you need to install different versions of Java, use alternative installation methods such as [_SDKMAN!_](https://sdkman.io/).
 
 :::
 
@@ -17,11 +17,11 @@ All Java packages in the Solus repositories include the _Java Runtime Environmen
 
 The following table lists the versions of Java available in the Solus repositories.
 
-|Version |Package name |Installation directory |Included components
-|---|-----|-----|-----|
-|Java 8| `openjdk-8` |`/usr/lib64/openjdk-8`|JRE, JDK|
-|Java 11| `openjdk-11` |`/usr/lib64/openjdk-11`|JRE, JDK, OpenJFX|
-|Java 17| `openjdk-17` |`/usr/lib64/openjdk-17`|JRE, JDK, OpenJFX|
+|Version |Package name |Installation directory |Included components|Notes
+|---|-----|-----|-----|-----|
+|Java 8| `openjdk-8` |`/usr/lib64/openjdk-8`|JRE, JDK|See openjdk-8 below|
+|Java 11| `openjdk-11` |`/usr/lib64/openjdk-11`|JRE, JDK, OpenJFX||
+|Java 17| `openjdk-17` |`/usr/lib64/openjdk-17`|JRE, JDK||
 
 
 ## Running Java Applications
@@ -38,3 +38,9 @@ There are multiple ways to execute Java applications in Solus:
 - Create a script that sets `JAVA_HOME` before running the application.
 - Symlink the java executable from `/path/to/jdk/bin` to `/usr/bin`.
 - Add `/path/to/jdk/bin` to your PATH environment variable.
+
+## openjdk-8
+
+:::danger Important
+
+openjdk-8 is scheduled for removal in the near future. It is not recommended that you use it today.


### PR DESCRIPTION
## Description

Add note on openjdk-8 being removed in the near future, remove openjfx from Java 17 (we've never built it)

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
