### PR TITLE
Change to a some more solus-like blues

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,25 +6,26 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary: #2374d3;
+  --ifm-color-primary-dark: #2068be;
+  --ifm-color-primary-darker: #1e63b3;
+  --ifm-color-primary-darkest: #1c5da9;
+  --ifm-color-primary-light: #3280dd;
+  --ifm-color-primary-lighter: #3c87df;
+  --ifm-color-primary-lightest: #5c9ae4;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
+
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme="dark"] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+[data-theme='dark'] {
+  --ifm-color-primary: #5294e2;
+  --ifm-color-primary-dark: #3884de;
+  --ifm-color-primary-darker: #2a7cdb;
+  --ifm-color-primary-darkest: #1f65b9;
+  --ifm-color-primary-light: #6ca4e6;
+  --ifm-color-primary-lighter: #7aace9;
+  --ifm-color-primary-lightest: #a1c5ef;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## Description

Change the base colors for theming to some more Solus-like blues

I took the Solus blue from the homepage banner as a starting point (#5294E2) Then used the docusauraurus page [here](https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima) to fiddle with the colors for light and dark theme.

Light theme base is Solus blue darkened by 20, Dark base is solus blue.

Note, you can use that site for some live-previewing of colors


A couple screen shots

![light2](https://github.com/getsolus/help-center-docs/assets/23007135/75510e33-3e81-49d5-8921-3f2275720167)

![light](https://github.com/getsolus/help-center-docs/assets/23007135/ecf8790c-2bb1-43df-ac15-14e96274f02d)

![dark2](https://github.com/getsolus/help-center-docs/assets/23007135/cf4b23f5-a01a-41b9-a097-ccd7356dad78)

![dark](https://github.com/getsolus/help-center-docs/assets/23007135/97186742-7c7f-4c3c-967b-e0eee776d8d6)



### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
