### PR TITLE
Rework "Requesting a package"

### DIFF
--- a/docs/packaging/procedures/package-inclusion.md
+++ b/docs/packaging/procedures/package-inclusion.md
@@ -11,7 +11,7 @@ This policy sets forth the criteria for a package to be accepted for inclusion i
 
 ### Explicitly Redistributable
 
-- Software under a free software or open source software license, or license text which explicitly states that it is **permissible** to redistribute the software.
+- Software under a free software or open source software license, or license text which explicitly states that it is **permissible** to redistribute the software. We use the [SPDX License List](https://spdx.org/licenses/).
 - For anything that cannot be redistributed by Solus, there is the possibility for them to be provided as a Flatpak, for Third Party repository inclusion, however the Solus project is not responsible for flatpak or snap implementation of these items. These items should then fetch only at installation time, and not contain non distributable components.
 - Solus supports both VCS (currently only git, this will expand) and traditional software sources (such as tarballs) for packages, equally.
 - Unless **absolutely unavoidable**, the sources for a package should be source, and not **binary, prebuilt** sources. Exceptions may be made in rare cases, such as stage1 bootstrap for a compiler, or requires custom components otherwise impossible to provide in Solus (patched libraries, etc.)

--- a/docs/packaging/procedures/request-a-package.md
+++ b/docs/packaging/procedures/request-a-package.md
@@ -5,18 +5,18 @@ summary: Requesting a new package
 
 # Requesting A Package
 
-Packages are how users install Software in Solus, however if we are missing one you can let us know using our Task Tracker.
+If you think Solus is missing a package that would be useful, you can let us know using our Issue Tracker.
 
-**Please [look to see if an issue has been filed](https://github.com/getsolus/packages/issues?q=label%3A%22Package+Request%22) for the software or library you require**. If there isn't an existing request, you can use the template below for requesting packages to be added to the Solus Package Repository. The Third Party Repository has been deprecated and will not be accepting any new packages.
+## Steps to request a new package
 
-You will be asked in the form to provide the following information, please provide as much as possible:
-
-- Name
-- Homepage
-- Why should this be included in the repository? If we already offer similar software in our repository **or third party**, please provide information on what your proposed software does that our existing offerings don't (_differentiators_).
-- Is it Open Source (yes/no)
-- If no: Are we allowed to distribute it?
-- Who and how many users do you anticipate will use this software?
-- Link to source tarball/zip file. master.zip files **are not permitted**. We require versioned tarballs, for example: "1.2.3.tar.gz" or "packagename-1.2.3".
-
-Please put this information in a new [issue](https://github.com/getsolus/packages/issues/new?assignees=&labels=Package+Request%2CPriority%3A+Wishlist&projects=&template=request-new-package.yml&title=What%27s+the+package+name%3F).
+1. [Look to see if an issue has already been filed](https://github.com/getsolus/packages/issues?q=label%3A%22Package+Request%22) for the package you want. If there is already request for your package, please do not open another issue. Instead, add your comments to the existing issue.
+2. Skim our [Package inclusion policy](/docs/packaging/procedures/package-inclusion.md) to make sure your request won't be rejected.
+3. Open a new [issue](https://github.com/getsolus/packages/issues/new?assignees=&labels=Package+Request%2CPriority%3A+Wishlist&projects=&template=request-new-package.yml&title=What%27s+the+package+name) for your package using the _Request a new package_ template. The template will ask you for the following information. Please complete as much as you can.
+   - Name
+   - Homepage
+   - Why should this be included in the repository? If we already offer similar packages in our repository **or third party repository**, please tell us what your new package does that our existing packages do not (_How is it different or better_).
+   - Are we allowed to distribute it?
+     - For Solus to distribute the package it must use a license found on the [SPDX License List](https://spdx.org/licenses/), or Solus must be given permission to redistribute it by the owner.
+   - What kind of user will use this package, and how many users do you think will use this package?
+   - Link to source tarball/zip file. This must point to a stable, versioned source, for example: `1.2.3.tar.gz` or `packagename-1.2.3`. Nightlies, snapshots and pre-releases are not allowed.
+4. Wait for Solus Staff to approve or reject your request.


### PR DESCRIPTION
- A user recently tripped over the old phrasing "Task Tracker"
- Make steps in a sensible order
- Simplify some wording
- Add a brief explanation of allowable licenses with the SPDX list, as this is a common misunderstanding
- Also link the SPDX list in the "Package Inclusion" page

Corresponding PR for the template: https://github.com/getsolus/packages/pull/806
