### PR TITLE
Remove links to Twitter

### DIFF
--- a/docs/user/contributing/getting-involved.md
+++ b/docs/user/contributing/getting-involved.md
@@ -38,7 +38,6 @@ Alongside the forums, you can communicate with developers or others in the commu
 - [Facebook](https://www.facebook.com/get.solus)
 - [Mastodon](https://fosstodon.org/@Solus)
 - [Reddit](https://www.reddit.com/r/SolusProject/)
-- [Twitter](https://twitter.com/solusproject)
 
 ## Funding
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,11 +140,6 @@ const config = {
                 href: "https://matrix.to/#/#solus:matrix.org",
               },
               {
-                label: "Twitter",
-                href: "https://twitter.com/SolusProject",
-                rel: "me",
-              },
-              {
                 label: "Mastodon",
                 href: "https://fosstodon.org/@Solus",
                 rel: "me",

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -23,10 +23,6 @@
     "message": "Matrix",
     "description": "The label of footer link with label=Matrix linking to https://matrix.to/#/#solus:matrix.org"
   },
-  "link.item.label.Twitter": {
-    "message": "Twitter",
-    "description": "The label of footer link with label=Twitter linking to https://twitter.com/SolusProject"
-  },
   "link.item.label.Mastodon": {
     "message": "Mastodon",
     "description": "The label of footer link with label=Mastodon linking to https://fosstodon.org/@Solus"


### PR DESCRIPTION
## Description

Removed links to Twitter since we are no longer actively promoting there.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
