### PR TITLE
Remove Skype from Third Party Software

### DIFF
--- a/docs/user/software/third-party/index.md
+++ b/docs/user/software/third-party/index.md
@@ -43,13 +43,6 @@ sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-par
 sudo eopkg it franz*.eopkg;sudo rm franz*.eopkg
 ```
 
-### Skype for Linux
-
-```bash
-sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/skype/pspec.xml
-sudo eopkg it skype*.eopkg;sudo rm *.eopkg
-```
-
 ### Slack
 
 ```bash


### PR DESCRIPTION
## Description
This removes Skype from the Third Party Software article

Microsoft no longer provides updated .deb archives

See here for details: https://answers.microsoft.com/en-us/skype/forum/all/skype-for-linux-updates/da864865-d9e9-4819-8a5d-8de8934dd312

Corresponding 3rd-party PR: https://github.com/getsolus/3rd-party/pull/76
Corresponding solus-sc PR: https://github.com/getsolus/solus-sc/pull/289

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
