### PR TITLE
Rename "Help Center Home", add Devlog

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,6 +113,41 @@ const config = {
             label: "Dev Log",
             position: "left",
           },
+          {
+            label: "More",
+            items: [
+              {
+                href: "https://getsol.us",
+                label: "Solus Homepage",
+              },
+              {
+                label: "Forums",
+                href: "https://discuss.getsol.us/",
+              },
+              {
+                href: "https://matrix.to/#/#solus:matrix.org",
+                label: "Matrix",
+              },
+              {
+                label: "Mastodon",
+                href: "https://fosstodon.org/@Solus",
+              },
+              {
+                label: "Github",
+                href: "https://github.com/getsolus",
+              },
+              {
+                label: "Packages",
+                href: "https://dev.getsol.us/",
+              },
+              {
+                label: "Issue Tracker",
+                href: "https://issues.getsol.us/",
+              },
+            ],
+            type: "dropdown",
+            position: "left",
+          },
         ],
       },
       footer: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -122,8 +122,25 @@ const config = {
             title: "Docs",
             items: [
               {
-                label: "Welcome",
+                label: "Users",
                 to: "/docs/user/intro",
+              },
+              {
+                label: "Packaging",
+                to: "/docs/packaging",
+              },
+            ],
+          },
+          {
+            title: "News",
+            items: [
+              {
+                label: "Solus Blog",
+                to: "https://getsol.us/blog",
+              },
+              {
+                label: "Solus Devlog",
+                to: "blog",
               },
             ],
           },
@@ -149,8 +166,8 @@ const config = {
             title: "More",
             items: [
               {
-                label: "Blog",
-                to: "https://getsol.us/blog",
+                label: "Solus Homepage",
+                to: "https://getsol.us/",
               },
               {
                 label: "GitHub",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -100,7 +100,7 @@ const config = {
             type: "docSidebar",
             sidebarId: "userSidebar",
             position: "left",
-            label: "Help Center Home",
+            label: "Users",
           },
           {
             type: "docSidebar",

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -3,6 +3,10 @@
     "message": "Docs",
     "description": "The title of the footer links column with title=Docs in the footer"
   },
+  "link.title.News": {
+    "message": "News",
+    "description": "The title of the footer links column with title=News in the footer"
+  },
   "link.title.Community": {
     "message": "Community",
     "description": "The title of the footer links column with title=Community in the footer"
@@ -11,9 +15,21 @@
     "message": "More",
     "description": "The title of the footer links column with title=More in the footer"
   },
-  "link.item.label.Welcome": {
-    "message": "Welcome",
-    "description": "The label of footer link with label=Welcome linking to /docs/user/intro"
+  "link.item.label.Users": {
+    "message": "Users",
+    "description": "The label of footer link with label=Users linking to /docs/user/intro"
+  },
+  "link.item.label.Packaging": {
+    "message": "Packaging",
+    "description": "The label of footer link with label=Packaging linking to /docs/user/packaging"
+  },
+  "link.item.label.SolusBlog": {
+    "message": "SolusBlog",
+    "description": "The label of footer link with label=SolusBlog linking to  https://getsol.us/blog"
+  },
+  "link.item.label.SolusDevlog": {
+    "message": "Solus Devlog",
+    "description": "The label of footer link with label=Users linking to /blog"
   },
   "link.item.label.Forums": {
     "message": "Forums",
@@ -27,9 +43,9 @@
     "message": "Mastodon",
     "description": "The label of footer link with label=Mastodon linking to https://fosstodon.org/@Solus"
   },
-  "link.item.label.Blog": {
-    "message": "Blog",
-    "description": "The label of footer link with label=Blog linking to https://getsol.us/blog"
+  "link.item.label.SolusHomepage": {
+    "message": "Solus Homepage",
+    "description": "The label of footer link with label=SolusHomepage linking to https://getsol.us/"
   },
   "link.item.label.GitHub": {
     "message": "GitHub",

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -1,15 +1,15 @@
 {
   "title": {
-    "message": "Solus",
+    "message": "Solus Help Center",
     "description": "The title in the navbar"
   },
   "logo.alt": {
     "message": "Solus Logo",
     "description": "The alt text of navbar logo"
   },
-  "item.label.Help Center Home": {
-    "message": "Help Center Home",
-    "description": "Navbar item with label Help Center Home"
+  "item.label.Users": {
+    "message": "Users",
+    "description": "Navbar item with label Users"
   },
   "item.label.Packaging": {
     "message": "Packaging",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,12 +7,13 @@ import { DocSection } from "../types";
 
 import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined";
 import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
+import EngineeringOutlinedIcon from "@mui/icons-material/EngineeringOutlined";
 import Doc from "../components/home/Doc";
 import Header from "../components/home/Header";
 
 const DocList: DocSection[] = [
   {
-    title: "Help Center Home",
+    title: "Users",
     description: <>Installing, software, boot management, troubleshooting and more</>,
     link: "docs/user/intro",
     img: <PersonOutlineOutlinedIcon sx={{ fontSize: 96 }} />,
@@ -22,6 +23,12 @@ const DocList: DocSection[] = [
     description: <>Get to grips with our advanced packaging features using easy to follow guides</>,
     link: "docs/packaging",
     img: <Inventory2OutlinedIcon sx={{ fontSize: 96 }} />,
+  },
+  {
+    title: "Dev Log",
+    description: <>Learn what our developers have been up to</>,
+    link: "blog",
+    img: <EngineeringOutlinedIcon sx={{ fontSize: 96 }} />,
   },
 ];
 
@@ -33,8 +40,8 @@ const Docs = () => {
         <Grid2
           columns={{
             xs: 6,
-            sm: 6,
-            md: 12,
+            sm: 18,
+            md: 18,
           }}
           container
           margin={0}


### PR DESCRIPTION
Changes:
- index.tsx: Add a "Devlog" entry to match the navbar
- navbar and index.tsx: Rename "Help Center Home" to "Users"
- navbar: Change the leftmost entry (which points to the index) from "Solus" to "Solus Help Center"
- Rework the index grid for 3 entries

Rationale:
- "Help Center Home" is too generic, "Users" is more specific
- The actual "home" (top level page for https://help.getsol.us) is somewhere else

Bikeshedding: Suggest a better icon for "devlog" from here https://mui.com/material-ui/material-icons/?query=fe&theme=Outlined


![Screenshot_20240129_184812](https://github.com/getsolus/help-center-docs/assets/23007135/21b6c208-9f56-4571-9186-2de2c611548e)

