### PR TITLE
package.yml: document kernel and Python version macros

### DIFF
--- a/docs/packaging/package.yml.md
+++ b/docs/packaging/package.yml.md
@@ -216,23 +216,27 @@ BOLT is a post-link optimizer developed to speed up large applications. You will
 
 ### Variable Macros
 
-| Macro             | Description                                                                                                                                       |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **%ARCH%**        | Indicates the current build architecture.                                                                                                         |
-| **%CC%**          | C compiler.                                                                                                                                       |
-| **%CFLAGS%**      | cflags as set in `eopkg.conf`.                                                                                                                    |
-| **%CONFOPTS%**    | Flags / options for configuration, such as `--prefix=%PREFIX%`. [Full List.](https://github.com/getsolus/ypkg/blob/master/ypkg2/rc.yml#L403-L415) |
-| **%CXX%**         | C++ compiler.                                                                                                                                     |
-| **%CXXFLAGS%**    | cxxflags as set in `eopkg.conf`.                                                                                                                  |
-| **%JOBS%**        | jobs, as set in `eopkg.conf`.                                                                                                                     |
-| **%LDFLAGS%**     | ldflags as set in `eopkg.conf`.                                                                                                                   |
-| **%LIBSUFFIX%**   | Library suffix (either 32 for 32-bit or 64 for 64-bit).                                                                                           |
-| **%PREFIX%**      | Hard-coded prefix `/usr`.                                                                                                                         |
-| **%YJOBS%**       | Job count without `-j` as set in `eopkg.conf`.                                                                                                    |
-| **%installroot%** | Hard-coded install directory.                                                                                                                     |
-| **%libdir%**      | The distribution’s default library directory, i.e. `/usr/lib64` (Alters for `emul32`).                                                            |
-| **%version%**     | Version of the package, as specified in the `version` key.                                                                                        |
-| **%workdir%**     | Hard-coded work directory (source tree).                                                                                                          |
+| Macro                        | Description                                                                                                                                       |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **%ARCH%**                   | Indicates the current build architecture.                                                                                                         |
+| **%CC%**                     | C compiler.                                                                                                                                       |
+| **%CFLAGS%**                 | cflags as set in `eopkg.conf`.                                                                                                                    |
+| **%CONFOPTS%**               | Flags / options for configuration, such as `--prefix=%PREFIX%`. [Full List.](https://github.com/getsolus/ypkg/blob/master/ypkg2/rc.yml#L403-L415) |
+| **%CXX%**                    | C++ compiler.                                                                                                                                     |
+| **%CXXFLAGS%**               | cxxflags as set in `eopkg.conf`.                                                                                                                  |
+| **%JOBS%**                   | jobs, as set in `eopkg.conf`.                                                                                                                     |
+| **%LDFLAGS%**                | ldflags as set in `eopkg.conf`.                                                                                                                   |
+| **%LIBSUFFIX%**              | Library suffix (either 32 for 32-bit or 64 for 64-bit).                                                                                           |
+| **%PREFIX%**                 | Hard-coded prefix `/usr`.                                                                                                                         |
+| **%YJOBS%**                  | Job count without `-j` as set in `eopkg.conf`.                                                                                                    |
+| **%installroot%**            | Hard-coded install directory.                                                                                                                     |
+| **%libdir%**                 | The distribution’s default library directory, i.e. `/usr/lib64` (Alters for `emul32`).                                                            |
+| **%version%**                | Version of the package, as specified in the `version` key.                                                                                        |
+| **%workdir%**                | Hard-coded work directory (source tree).                                                                                                          |
+| **%kernel_version_lts%**     | Version of the `linux-lts` kernel.                                                                                                                |
+| **%kernel_version_current%** | Version of the `linux-current` kernel.                                                                                                            |
+| **%python2_version%**        | Version of the `python` (Python 2) distribution.                                                                                                  |
+| **%python3_version%**        | Version of the `python3` distribution.                                                                                                            |
 
 ## Variables
 


### PR DESCRIPTION
## Description

This adds the macros to get the kernel and Python versions to the `package.yml` doc.

(the last four items in the table, the diff is messy due to the prettier having to reformat the whole table)
