### PR TITLE
Add "Translation instructions" stub page

### DIFF
--- a/docs/packaging/translation-instructions.md
+++ b/docs/packaging/translation-instructions.md
@@ -1,0 +1,12 @@
+---
+title: Translation instructions
+summary: Instructions for translators
+---
+
+# Translation instructions
+
+🚧 This page is a stub for now.
+
+Users will arrive here from the "Translation instructions" link on Transifex.
+
+Please join our [Matrix rooms](/docs/user/contributing/getting-involved.md#matrix-chat) if you have questions about our translation projects.


### PR DESCRIPTION
Add a stub page for "Translation Instructions"
Transifex project setup includes a link specific to this.
Unsure whether this is "User" or "Packaging", leaning towards packaging because it is where other "contribution" stuff goes
