### PR TITLE
docs/packaging: Create a section on using github-cli to make a pull request

### DIFF
--- a/docs/packaging/creating-a-new-package.md
+++ b/docs/packaging/creating-a-new-package.md
@@ -196,4 +196,4 @@ For more information on suitable commit messages, please check the [tooling cent
 - If you want to link this pull request to an existing package request, simply mention it in your commit message (use the full URL): `The inclusion of <somepackage> resolves https://github.com/getsolus/packages/issues/123`
 - If you need a change to depend on another change, mention it in the commit message too (use the full URL): `Depends on https://github.com/getsolus/packages/issues/234`
 
-Next, you'll [submit a pull request for review](submitting-a-pull-request.md).
+Next, you'll [submit a pull request for review](submitting-a-pull-request.mdx).

--- a/docs/packaging/index.md
+++ b/docs/packaging/index.md
@@ -30,4 +30,4 @@ Please check the following:
 - For updating a package that already is in the repos see [Updating an Existing Package](updating-an-existing-package.md)
 
 3. [Test the Package](testing-a-package.md)
-4. [Submit a Pull Request for Review](submitting-a-pull-request.md)
+4. [Submit a Pull Request for Review](submitting-a-pull-request.mdx)

--- a/docs/packaging/submitting-a-pull-request.mdx
+++ b/docs/packaging/submitting-a-pull-request.mdx
@@ -4,6 +4,11 @@ summary: Submitting a Pull Request for Review
 sidebar_position: 6
 ---
 
+import Admonition from "@theme/Admonition";
+import CodeBlock from "@theme/CodeBlock";
+import TabItem from "@theme/TabItem";
+import Tabs from "@theme/Tabs";
+
 # Submitting a Pull Request for Review
 
 Please refrain from submitting a pull request for the following instances:
@@ -37,25 +42,52 @@ git log -1
 
 ## Creating the Pull Request
 
-In the package folder, run `git push`.
+There are multiple ways to create a Pull Request with GitHub, either from the website, or from the command line.
 
-:::note
+<Tabs groupId="opening-prs">
+  <TabItem value="website" label="Website">
+    <p>
+    In the package folder, push your local changes to a remote branch:
 
-If you've created your own branch, as recommended, the cli tool will show you a new command to create and push to a remote branch matching the local one. Run this.
+    <CodeBlock language="bash">
+      git push
+    </CodeBlock>
+    </p>
+    <Admonition type="info">
+      If you've created your own branch, as recommended, the CLI tool will show you a new command to create and push to a remote branch matching the local one. Run this.
+    </Admonition>
+    <p>
+    Once the commit is successfully pushed, you'll notice that a URL will be provided that will immediately allow you to create a pull request with your changes.
 
-:::
+    Run `git status` one last time to make sure your branch is clean. If it is:
 
-Once the commit is successfully pushed, you'll notice that a URL will be provided that will immediately allow you to create a pull request with your changes.
+    1. Open the link.
+    2. Fill in a summary of your changes (usually the same as the commit message).
+    3. Link any relevant issues:
+       - If you want to link this pull request to an existing issue, simply mention it in the PR summary: `The inclusion of <somepackage> fixes #123`.
+       - If you need a change to depend on another change, mention it in the PR summary too: `Depends on #234`.
+    4. Double check everything
+    5. Create the pull request!
+    </p>
 
-Run `git status` one last time to make sure your branch is clean. If it is:
+  </TabItem>
+  <TabItem value="github-cli" label="GitHub CLI">
+    <p>
+    In the package folder, run the `gh` command:
+    </p>
+    <CodeBlock language="bash">
+      gh pr create
+    </CodeBlock>
+    <p>
+    This will start an interactive session to create your pull request step-by-step.
 
-1. Open the link.
-2. Fill in a summary of your changes (usually the same as the commit message).
-3. Link any relevant issues:
-   - If you want to link this pull request to an existing issue, simply mention it in the PR summary: `The inclusion of <somepackage> fixes #123`.
-   - If you need a change to depend on another change, mention it in the PR summary too: `Depends on #234`.
-4. Double check everything
-5. Create the pull request!
+    When the current branch isn't fully pushed to a git remote, a prompt will ask where to push the branch and offer an option to fork the base repository. For community packagers, you should use your fork of the packages repository. If you are a member of the Solus Staff, you should use `getsolus/packages`.
+    </p>
+    <Admonition type="info">
+      The text editor used by `github-cli` may not the same one that `git` uses. To change this, consult the [`gh config set` command](https://cli.github.com/manual/gh_config_set).
+    </Admonition>
+  </TabItem>
+</Tabs>
 
 ## Amending a Pull Request
 

--- a/docs/packaging/updating-an-existing-package.md
+++ b/docs/packaging/updating-an-existing-package.md
@@ -190,4 +190,4 @@ As stated previously, `[NFC]` is an abbreviation of "No Functional Change".
 
 For more information on suitable commit messages, please check the [tooling central documentation](https://github.com/solus-project/tooling-central/blob/master/README.rst#using-git).
 
-Next, you'll [submit a pull request for review](submitting-a-pull-request.md).
+Next, you'll [submit a pull request for review](submitting-a-pull-request.mdx).


### PR DESCRIPTION
## Description

Adds a section to the "Submitting a pull request" article about using `github-cli` to make it.

This uses a tab group so the reader can switch between versions for creating a PR.