### PR TITLE
Reduce code element border radius and add padding

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -13,7 +13,9 @@
   --ifm-color-primary-light: #3280dd;
   --ifm-color-primary-lighter: #3c87df;
   --ifm-color-primary-lightest: #5c9ae4;
+  --ifm-code-border-radius: 0.25rem;
   --ifm-code-font-size: 95%;
+  --ifm-code-padding-horizontal: 0.15rem;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
## Description

This reduces the border radius for code elements and slightly increases horizontal padding. The default rounding looks too extreme in my eyes, and makes it feel like the characters are not properly contained, especially with big vertical characters at the start or end of the element.

Before:
![](https://i.imgur.com/KMiQbc5.png)

After:
![](https://i.imgur.com/w2S5yjV.png)

Note: Personally I'm somewhat partial to a completely angular style for these elements, but this might be too extreme and/or not fit in with the rest of the theming

0 border radius:
![](https://i.imgur.com/Q5MzLWb.png)

It also looks more consistent across line breaks (which are not ideal in any case, but that's a different topic)
![](https://i.imgur.com/KlAQTUM.png)