### PR TITLE
Add bash syntax highlighter

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -225,6 +225,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['bash'],
       },
     }),
 };


### PR DESCRIPTION
## Description

This adds the `bash` syntax highlighter from `prismjs`, which is not part of [the standard set of languages for prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L10-L25) (anymore?)

Before:
![](https://i.imgur.com/MACsczM.png)

After:
![](https://i.imgur.com/ICN3NLQ.png)