### PR TITLE
Add more missing syntax highlighters, add more meta strings to code

### DIFF
--- a/docs/user/hardware/peripherals/mice-and-touchpads.md
+++ b/docs/user/hardware/peripherals/mice-and-touchpads.md
@@ -53,7 +53,7 @@ If it returns a result, then success! The synaptics driver is in use instead of 
 
 If you wish to switch back to using libinput:
 
-```
+```bash
 sudo rm /etc/X11/xorg.conf.d/90-synaptics.conf
 sudo eopkg rm xorg-driver-input-synaptics
 ```

--- a/docs/user/quick-start/boot-management.md
+++ b/docs/user/quick-start/boot-management.md
@@ -21,7 +21,7 @@ By default, EFI installs will not show the boot menu and boot directly into Solu
 
 The following command will set the timeout of the boot loader to five seconds so that it appears by default:
 
-```
+```bash
 sudo clr-boot-manager set-timeout 5 && sudo clr-boot-manager update
 ```
 
@@ -29,7 +29,7 @@ sudo clr-boot-manager set-timeout 5 && sudo clr-boot-manager update
 
 Kernel parameters can be appended to boot via creating a file for `clr-boot-manager` to use when updating kernels. For example, to add `nomodeset` to boot options, you would create a file in `/etc/kernel/cmdline.d` (as sudo):
 
-```
+```bash
 sudo mkdir -p /etc/kernel/cmdline.d
 echo 'nomodeset' | sudo tee /etc/kernel/cmdline.d/40_nomodeset.conf
 ```

--- a/docs/user/software/desktops/index.md
+++ b/docs/user/software/desktops/index.md
@@ -46,7 +46,7 @@ sudo eopkg install -c desktop.mate
 
 Solus offers the XFCE desktop environment for users preferring a more lightweight experience. It is recommended for existing MATE users. You can install XFCE with the following command:
 
-```
+```bash
 # Do NOT attempt to do this if you are running the KDE Plasma Desktop version of Solus!
 sudo eopkg install -c desktop.xfce
 ```

--- a/docs/user/software/development/postgresql.md
+++ b/docs/user/software/development/postgresql.md
@@ -11,13 +11,13 @@ summary: A quick guide to using Postgres on Solus
 
 PostgreSQL can be installed either from the Software Center or via terminal:
 
-```
+```bash
 sudo eopkg install postgresql
 ```
 
 Management of the server can be done using Systemd:
 
-```
+```bash
 sudo systemctl enable postgresql # Start the server on boot
 sudo systemctl start postgresql  # Start the server now
 sudo systemctl stop postgresql   # Stop the server
@@ -25,7 +25,7 @@ sudo systemctl stop postgresql   # Stop the server
 
 It is possible to connect to the database using the PostgreSQL user:
 
-```
+```bash
 sudo -u postgres psql
 ```
 
@@ -37,20 +37,20 @@ Because PostgreSQL is included as a single package, the only way to perform a ma
 
 1.  If you have already updated PostgreSQL, downgrade PostgreSQL back to 15.4:
 
-```
+```bash
 sudo eopkg it https://cdn.getsol.us/repo/shannon/p/postgresql/postgresql-15.4-42-1-x86_64.eopkg \
               https://cdn.getsol.us/repo/shannon/p/postgresql/postgresql-libpq-15.4-42-1-x86_64.eopkg
 ```
 
 2.  (Re)start PostgreSQL:
 
-```
+```bash
 sudo systemctl restart postgresql
 ```
 
 3.  Create a backup of all current data:
 
-```
+```bash
 sudo -u postgres pg_dumpall -f /tmp/backup.sql
 ```
 
@@ -58,38 +58,38 @@ The location of the backup may be one of your choosing, but keep in mind that th
 
 4.  Stop PostgreSQL:
 
-```
+```bash
 sudo systemctl stop postgresql
 ```
 
 5.  Rename the old data directory. This directory contains the old configuration and the original database, but requires significant disk space.
 
-```
+```bash
 sudo mv /var/db/pgsql/data /var/db/pgsql/data.old
 ```
 
 6.  Create a new data directory:
 
-```
+```bash
 sudo mkdir /var/db/pgsql/data
 sudo chown postgres: /var/db/pgsql/data
 ```
 
 7.  Upgrade PostgreSQL:
 
-```
+```bash
 sudo eopkg upgrade
 ```
 
 8.  Start PostgreSQL:
 
-```
+```bash
 sudo systemctl start postgresql
 ```
 
 9.  Restore the data:
 
-```
+```bash
 sudo -u postgres psql < /tmp/backup.sql
 ```
 
@@ -99,6 +99,6 @@ sudo -u postgres psql < /tmp/backup.sql
 
 12. Remove the backup and data dump:
 
-```
+```bash
 sudo rm -r /var/db/pgsql/data.old /tmp/backup.sql
 ```

--- a/docs/user/software/networking/samba.md
+++ b/docs/user/software/networking/samba.md
@@ -257,7 +257,7 @@ In the _smbd_ manual page (`man 8 smbd`), it is shown how the compiled-in defaul
 
 To use the traditional `/etc/samba/smb.conf` configuration file exclusively (thus bypassing the Solus configuration), edit the `/etc/sysconfig/samba` file to look like so:
 
-```bash
+```ini
 ## Path:           Network/Samba
 ## Description:    Samba process options
 ## Type:           string

--- a/docs/user/software/utilities/kwallet.md
+++ b/docs/user/software/utilities/kwallet.md
@@ -31,7 +31,7 @@ The contents of `~/.config/autostart/ssh-add.desktop` should reflect the SSH key
 
 Below is an example of the contents of `~/.config/autostart/ssh-add.desktop`:
 
-```
+```ini
 [Desktop Entry]
 Exec=ssh-add -q
 Name=ssh-add
@@ -40,7 +40,7 @@ Type=Application
 
 Tip: The above ssh-add.desktop file will only add the default key `~/.ssh/id_rsa`. Assuming you have different keys named key1, key2 etc you need to change the above desktop file to
 
-```
+```ini
 [Desktop Entry]
 Exec=ssh-add -q ~/.ssh/key1 ~/.ssh/key2 ~/.ssh/key3
 Name=ssh-add
@@ -51,7 +51,7 @@ Type=Application
 
 After you created your file inside the autostart folder you have to give it the correct permissions
 
-```
+```bash
 chmod 700 ~/.config/autostart/ssh-add.desktop
 ```
 
@@ -71,6 +71,6 @@ For this to work, your KDE Wallet password needs to be identical to your login p
 
 ssh key doesn't get triggered, you can force this manually by running this command.
 
-```
+```bash
 SSH_ASKPASS=/usr/bin/ksshaskpass ssh-add < /dev/null
 ```

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -225,7 +225,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ["bash"],
+        additionalLanguages: ["bash", "diff", "ini", "powershell"],
       },
     }),
 };


### PR DESCRIPTION
## Description

Add the missing syntax highlighting languages `ini`, `powershell` and `diff`. There were already code blocks with the corresponding language meta strings, but those had no effect without importing the languages [Note: they might have been part of the default list of languages with a previous Docusaurus/prism-react-renderer version]

Also add some more language meta strings to code blocks that were missing them.
