### PR TITLE
packaging: update commit instructions to follow Git commit hook and link package requests

### DIFF
--- a/docs/packaging/creating-a-new-package.md
+++ b/docs/packaging/creating-a-new-package.md
@@ -173,6 +173,7 @@ There should be a summary line (with the package name), a blank line, and then t
 
 - There should at the minimum be a Summary.
 - Bullet point lists should start with a dash.
+- Link the package request using a `Resolves` line.
 
 Here is an example in our standard format:
 
@@ -182,11 +183,14 @@ tree: Add at v2.1.1
 **Summary**
 
 Add the tree package, which recursively lists directories in a tree like manner.
+
+Resolves getsolus/packages#issuenumber
 ```
+
+Where `issuenumber` is the issue number of the package request.
 
 For more information on suitable commit messages, please check the [tooling central documentation](https://github.com/solus-project/tooling-central/blob/master/README.rst#using-git).
 
-- If you want to link this pull request to an existing package request, simply mention it in your commit message (use the full URL): `The inclusion of <somepackage> resolves https://github.com/getsolus/packages/issues/123`
-- If you need a change to depend on another change, mention it in the commit message too (use the full URL): `Depends on https://github.com/getsolus/packages/issues/234`
+If you need a change to depend on another change, mention it in the commit message too (use the full URL): `Depends on https://github.com/getsolus/packages/issues/234`
 
 Next, you'll [submit a pull request for review](submitting-a-pull-request.mdx).

--- a/docs/packaging/creating-a-new-package.md
+++ b/docs/packaging/creating-a-new-package.md
@@ -166,12 +166,15 @@ git commit
 
 ### Commit message format for new packages
 
+`git commit` on [an initialized repository](prepare-for-packaging.md#initialize-git-hooks) will automatically open your editor with the correct template.
+Note that lines starting with a `#` will be ignored by Git and do not need to be removed.
+
 There should be a summary line (with the package name), a blank line, and then the rest of the commit message.
 
-- There should at the minimum be a Summary and Test Plan.
+- There should at the minimum be a Summary.
 - Bullet point lists should start with a dash.
 
-Here is an example in our standard format (make sure to check the box in the checklist):
+Here is an example in our standard format:
 
 ```
 tree: Add at v2.1.1
@@ -179,16 +182,6 @@ tree: Add at v2.1.1
 **Summary**
 
 Add the tree package, which recursively lists directories in a tree like manner.
-
-**Test Plan**
-
-- Launched the application
-- Exercised the UI
-- Exercised some feature
-
-**Checklist**
-
-- [] Package was built and tested against unstable
 ```
 
 For more information on suitable commit messages, please check the [tooling central documentation](https://github.com/solus-project/tooling-central/blob/master/README.rst#using-git).

--- a/docs/packaging/packaging-changes.md
+++ b/docs/packaging/packaging-changes.md
@@ -15,6 +15,11 @@ This page is meant to serve as a changelog of sorts for the Solus packaging envi
 
 ### May
 
+#### Remove 'Test Plan' and 'Checklist' from commit messages
+
+- These are no longer needed in commit messages.
+- They must still be included in the pull request description.
+
 #### Add Rust macros to package.yml
 
 - We now have macros for building Rust packages. Example: `%cargo_build`. Rust packages should be switched to use the new macros as they are updated.

--- a/docs/packaging/updating-an-existing-package.md
+++ b/docs/packaging/updating-an-existing-package.md
@@ -128,7 +128,6 @@ The following guidelines apply to the commit message body:
 - Include a changelog with a brief list of updates from the upstream release notes, with no links or issue numbers.
 - There may also be a section for Solus specific work (e.g. rebuild against x / rework to remove dependency).
 - Optional: A link to the upstream release notes page.
-- Include your Test Plan.
 
 `git commit` on [an initialized repository](prepare-for-packaging.md#initialize-git-hooks) will automatically open your editor with the correct template.
 Note that lines starting with a `#` will be ignored by Git and do not need to be removed.
@@ -167,14 +166,6 @@ Enhancements:
 Full release notes:
 
 - [1.2.3](https://github.com/foo/foo/releases/tag/v1.2.3)
-
-**Test Plan**
-
-<!-- Short description of how the package was tested -->
-
-**Checklist**
-
-- [ ] Package was built and tested against unstable
 ```
 
 ### Other commit message format examples


### PR DESCRIPTION
## Description

- Add instructions to follow the template shown in the editor.
- Remove 'Test Plan' and 'Checklist' from example commits.
- Add to packaging changes.
- Add issue link for new packages.
