### PR TITLE
Fix bash for sending gists

### DIFF
--- a/docs/packaging/troubleshooting-packaging.md
+++ b/docs/packaging/troubleshooting-packaging.md
@@ -22,7 +22,7 @@ cat package.yml | gh gist create --public
 Send the output of `solbuild` to a public Gist:
 
 ```bash
-go-task &| gh gist create --public
+go-task |& gh gist create --public
 ```
 
 _Note: the usual `solbuild` output will not be shown when this command is running, and it will take at least a few seconds_
@@ -30,7 +30,7 @@ _Note: the usual `solbuild` output will not be shown when this command is runnin
 Send the output of `solbuild` to a new `output.txt` file:
 
 ```bash
-go-task &| tee output.txt
+go-task |& tee output.txt
 ```
 
 ## Common Issues


### PR DESCRIPTION
## Description
Fixes the bash command per help from @ermo 

From the bash man page:
If |& is used, command1's standard error, in addition to its standard output, is connected to command2's standard input through the pipe; it is shorthand for 2>&1 |.


