### PR TITLE
Devlog: Add authors.yml

### DIFF
--- a/devlog/2024-01-13-welcome-devlog.md
+++ b/devlog/2024-01-13-welcome-devlog.md
@@ -2,11 +2,7 @@
 title: Welcome to the Solus Devlog
 description: Welcome to the Solus Development Log.
 slug: welcome-solus-devlog-v1
-authors:
-  - name: Joey Riches
-    title: Solus Staff
-    url: https://github.com/joebonrichie
-    image_url: https://avatars.githubusercontent.com/u/5338090?s=400&u=f77ed45c7e83814ce3e8bd199fc293bd5b53682b&v=4
+authors: joey
 tags: [hello, devlog, firstpost, solus]
 hide_table_of_contents: false
 ---

--- a/devlog/2024-01-19-eopkg-is-dead.md
+++ b/devlog/2024-01-19-eopkg-is-dead.md
@@ -1,11 +1,7 @@
 ---
 title: eopkg is dead, long live eopkg
 slug: eopkg-is-dead-long-live-eopkg
-authors:
-  - name: David Harder
-    title: Solus Staff
-    url: https://github.com/davidjharder
-    image_url: https://avatars.githubusercontent.com/u/23007135?v=4
+authors: david
 tags: [eopkg, devlog, moss, solus]
 hide_table_of_contents: false
 ---

--- a/devlog/2024-01-29-dont-call-me-mate.md
+++ b/devlog/2024-01-29-dont-call-me-mate.md
@@ -1,11 +1,7 @@
 ---
 title: Don't call me MATE, pal!
 slug: don't-call-me-mate-pal
-authors:
-  - name: David Harder
-    title: Solus Staff
-    url: https://github.com/davidjharder
-    image_url: https://avatars.githubusercontent.com/u/23007135?v=4
+authors: david
 tags: [MATE, devlog, solus]
 hide_table_of_contents: false
 ---

--- a/devlog/2024-02-09-Intro-to-optimizing-packages-on-solus.md
+++ b/devlog/2024-02-09-Intro-to-optimizing-packages-on-solus.md
@@ -2,11 +2,7 @@
 title: Intro to Optimizing Packages on Solus
 description: Explore how to employ advanced compiler techniques such as PGO, BOLT & Glibc HWCaps to squeeze extra performance from packages using libwebp as a test vehicle
 slug: solus-optimizing-packages
-authors:
-  - name: Joey Riches
-    title: Solus Staff
-    url: https://github.com/joebonrichie
-    image_url: https://avatars.githubusercontent.com/u/5338090?s=400&u=f77ed45c7e83814ce3e8bd199fc293bd5b53682b&v=4
+authors: joey
 tags: [pgo, lto, solus, packaging, optimization, 03, clang, gnu, llvm, glibc, hwcaps, x86_64-v3]
 hide_table_of_contents: false
 ---

--- a/devlog/authors.yml
+++ b/devlog/authors.yml
@@ -1,0 +1,15 @@
+joey:
+  name: Joey Riches
+  title: Solus Staff
+  url: https://github.com/joebonrichie
+  image_url: https://avatars.githubusercontent.com/u/5338090?s=400&u=f77ed45c7e83814ce3e8bd199fc293bd5b53682b&v=4
+  socials:
+    github: joebonrichie
+
+david:
+  name: David Harder
+  title: Solus Staff
+  url: https://github.com/davidjharder
+  image_url: https://avatars.githubusercontent.com/u/23007135?v=4
+  socials:
+    github: davidjharder


### PR DESCRIPTION
## Description

Add an authors.yml for the Devlog

This fixes some warnings with newer Docusaurus and removes boilerplate
Should also make it easier to update author info in the future
