### PR TITLE
Boot Management: Add missing kernel modules

### DIFF
--- a/docs/user/quick-start/boot-management.md
+++ b/docs/user/quick-start/boot-management.md
@@ -52,9 +52,11 @@ By default, Solus utilizes our linux-current kernel. The separate kernel branche
 | nvidia-developer-driver | nvidia-developer-driver-current |
 | nvidia-glx-driver       | nvidia-glx-driver-current       |
 | openrazer               | openrazer-current               |
+| rtl8852bu               | rtl8852bu-current               |
 | v4l2loopback            | v4l2loopback-current            |
 | vhba-module             | vhba-module-current             |
 | virtualbox              | virtualbox-current              |
+| xone                    | xone-current                    |
 
 ### Change the default kernel branch to boot
 


### PR DESCRIPTION
## Description

The "Installing a different kernel branch" documentation is missing two packages that contain kernel modules and have to be changed when switching kernel branches.

This adds the two remaining packages to the list.