### PR TITLE
Update Docusaurus to 3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^1.2.0",
-    "@docusaurus/core": "3.3.2",
-    "@docusaurus/plugin-ideal-image": "3.3.2",
-    "@docusaurus/preset-classic": "3.3.2",
+    "@docusaurus/core": "3.5.2",
+    "@docusaurus/plugin-ideal-image": "3.5.2",
+    "@docusaurus/preset-classic": "3.5.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mdx-js/react": "^3.0.0",
@@ -34,8 +34,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/eslint-plugin": "^3.3.2",
-    "@docusaurus/module-type-aliases": "^3.3.2",
+    "@docusaurus/eslint-plugin": "3.5.2",
+    "@docusaurus/module-type-aliases": "3.5.2",
     "@tsconfig/docusaurus": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3608,9 +3608,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/core@npm:3.3.2"
+"@docusaurus/core@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/core@npm:3.5.2"
   dependencies:
     "@babel/core": ^7.23.3
     "@babel/generator": ^7.23.3
@@ -3622,12 +3622,12 @@ __metadata:
     "@babel/runtime": ^7.22.6
     "@babel/runtime-corejs3": ^7.22.6
     "@babel/traverse": ^7.22.8
-    "@docusaurus/cssnano-preset": 3.3.2
-    "@docusaurus/logger": 3.3.2
-    "@docusaurus/mdx-loader": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-common": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/cssnano-preset": 3.5.2
+    "@docusaurus/logger": 3.5.2
+    "@docusaurus/mdx-loader": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-common": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     autoprefixer: ^10.4.14
     babel-loader: ^9.1.3
     babel-plugin-dynamic-import-node: ^2.3.3
@@ -3681,68 +3681,69 @@ __metadata:
     webpack-merge: ^5.9.0
     webpackbar: ^5.0.2
   peerDependencies:
+    "@mdx-js/react": ^3.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
   bin:
     docusaurus: bin/docusaurus.mjs
-  checksum: 4b5100c0695f896f53a2a2103a3cd7d1685cf9708982dc13c391a2cae73d6f32dd76e9357b1771c18d3b08df4f90f3ee135b9260a5941e01e3211934dedfd93e
+  checksum: 6c6282a75931f0f8f8f8768232b4436ff8679ae12b619f7bd01e0d83aa346e24ab0d9cecac034f9dc95c55059997efdd963d052d3e429583bfb8d3b54ab750d3
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/cssnano-preset@npm:3.3.2"
+"@docusaurus/cssnano-preset@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/cssnano-preset@npm:3.5.2"
   dependencies:
     cssnano-preset-advanced: ^6.1.2
     postcss: ^8.4.38
     postcss-sort-media-queries: ^5.2.0
     tslib: ^2.6.0
-  checksum: cdb7b09a879e3f20faa2cd274bf37cb6b9d760a66268799f384be583e327b2269559e0fc2ee7d77ee5febe7293a4c4866edee8dd439efcef4d5545362e802838
+  checksum: 4bb1fae3741e14cbbdb64c1b0707435970838bf219831234a70cf382e6811ffac1cadf733d5e1fe7c278e7b2a9e533bfa802a5212b22ec46edd703208cf49f92
   languageName: node
   linkType: hard
 
-"@docusaurus/eslint-plugin@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/eslint-plugin@npm:3.3.2"
+"@docusaurus/eslint-plugin@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/eslint-plugin@npm:3.5.2"
   dependencies:
     "@typescript-eslint/utils": ^5.62.0
     tslib: ^2.6.0
   peerDependencies:
     eslint: ">=6"
-  checksum: 5379a2420c5e2f3ba1b83e947bcd9b9bb9e60c810e6824431d7ae1ab53caef422cbefffd9854990f70f2c5069d51621c315380140e52dab2a9eaeb6fe41aba2d
+  checksum: 6ec174c71682b1bcd2fca32ad5476d78e32c75fe6aa541b68f25c307e229f8cd95d9533880b719107f02af16b93d90fa00e8e2cd823306d873be53145c30791a
   languageName: node
   linkType: hard
 
-"@docusaurus/logger@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/logger@npm:3.3.2"
+"@docusaurus/logger@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/logger@npm:3.5.2"
   dependencies:
     chalk: ^4.1.2
     tslib: ^2.6.0
-  checksum: 8d45a67d55d6e829a3edcc49673864247e4ce0a6a0a342728d1b3afe48eeb4226202513dc1ef63d2b1229fd86f0bc0fdc11bba982e0fa444f2805395eab44e43
+  checksum: 7cbdcf54acd6e7787ca5a10b9c884be4b9e8fdae837862c66550a0bf3d02737f72c3188b2bddd61da6d8530eb2eb2b646ea599a79416e33c4998f1a87d2f6a8c
   languageName: node
   linkType: hard
 
-"@docusaurus/lqip-loader@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/lqip-loader@npm:3.3.2"
+"@docusaurus/lqip-loader@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/lqip-loader@npm:3.5.2"
   dependencies:
-    "@docusaurus/logger": 3.3.2
+    "@docusaurus/logger": 3.5.2
     file-loader: ^6.2.0
     lodash: ^4.17.21
     sharp: ^0.32.3
     tslib: ^2.6.0
-  checksum: 8d887dc2e9c0ea2584cc3d4c675dfc2c9cc00a58ff82491f6dfd582f9180e4f1b21d692266b0f4f80f537cbff57e031847e652ffd16effcdeebcda62acc1d737
+  checksum: be4ed78a06336719a118cda0f984986cb315137ad873412890ccd10bdec017dd355e31ba5a322970b0bd0891b092da2f9cef00fd746c6db4bfd7eff2f9de7ca3
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/mdx-loader@npm:3.3.2"
+"@docusaurus/mdx-loader@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/mdx-loader@npm:3.5.2"
   dependencies:
-    "@docusaurus/logger": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/logger": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     "@mdx-js/mdx": ^3.0.0
     "@slorber/remark-comment": ^1.0.0
     escape-html: ^1.0.3
@@ -3767,15 +3768,15 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 98a800ec05cf9d5da85d3109a5cb62eb5876d25126209fe9502ef45e8a9742e0a7d6d63c8a9a35f09001555828210660232f5500b9ea248d813db146ab2d4571
+  checksum: 36186c2f3487631757b24ba3a21575d2253ca1e6ada82d556bf323da7ae7637c0880eb388bf375e207bc5f26dcd8b58cc76d763e6c2caf6ed80f88748444ce8d
   languageName: node
   linkType: hard
 
-"@docusaurus/module-type-aliases@npm:3.3.2, @docusaurus/module-type-aliases@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/module-type-aliases@npm:3.3.2"
+"@docusaurus/module-type-aliases@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/module-type-aliases@npm:3.5.2"
   dependencies:
-    "@docusaurus/types": 3.3.2
+    "@docusaurus/types": 3.5.2
     "@types/history": ^4.7.11
     "@types/react": "*"
     "@types/react-router-config": "*"
@@ -3785,22 +3786,23 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 858f734379daac5622dfc04fa7f6b90bcffd33a5e7972d2f47c3b820564ea62f3e0b27bc1a55bc47ea3a23a52342bec844ce0db0bfcfcaf12e39490acd34e72a
+  checksum: 0161db859d459bb25ac162f0c509fb1316dfb403a9e89f325a9bc7d9f35ae1825b9703a435777903ba93de827d4413b189bbd0c03018ac13d66b50633302ea80
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-content-blog@npm:3.3.2"
+"@docusaurus/plugin-content-blog@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-content-blog@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/logger": 3.3.2
-    "@docusaurus/mdx-loader": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-common": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
-    cheerio: ^1.0.0-rc.12
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/logger": 3.5.2
+    "@docusaurus/mdx-loader": 3.5.2
+    "@docusaurus/theme-common": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-common": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
+    cheerio: 1.0.0-rc.12
     feed: ^4.2.2
     fs-extra: ^11.1.1
     lodash: ^4.17.21
@@ -3811,24 +3813,26 @@ __metadata:
     utility-types: ^3.10.0
     webpack: ^5.88.1
   peerDependencies:
+    "@docusaurus/plugin-content-docs": "*"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: e8a10b6b68dbc1396d60df3bff300f1e7220a46a24febb310b4432ed882cd3dd97c8c9bf9740d4a67935ae66d9826f87e2c5cbd037c8fa0a9e88819e5548f3b4
+  checksum: c5997b9d86ccf939998f9d56e65491ecf9e677d8425e95a79b3b428041d4dfc4ecb03a18ef595777c3ad5bd65f4a2dd30d99cb6f1b411161bf7cd32027ecc6d5
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-content-docs@npm:3.3.2"
+"@docusaurus/plugin-content-docs@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-content-docs@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/logger": 3.3.2
-    "@docusaurus/mdx-loader": 3.3.2
-    "@docusaurus/module-type-aliases": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-common": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/logger": 3.5.2
+    "@docusaurus/mdx-loader": 3.5.2
+    "@docusaurus/module-type-aliases": 3.5.2
+    "@docusaurus/theme-common": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-common": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     "@types/react-router-config": ^5.0.7
     combine-promises: ^1.1.0
     fs-extra: ^11.1.1
@@ -3840,102 +3844,102 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 410b223268d50878e96dc072a6172eaf5d4fb53d7a6f23465029abc1e201acd0a4b8da4b05af2df2dafb0172642c35b2ee19a49107a8c63ab1dd10e1a11f15f7
+  checksum: fb7ba7f8a6741b14bbe8db0bf1b12ff7a24d12c40d8276f32b9b393881d74bfed3bed4f1e5b0756cac0e43c4bd8106094d5cf6a3c527400e9713283fc3832dab
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-content-pages@npm:3.3.2"
+"@docusaurus/plugin-content-pages@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-content-pages@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/mdx-loader": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/mdx-loader": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     fs-extra: ^11.1.1
     tslib: ^2.6.0
     webpack: ^5.88.1
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 185ba1cb6abe4feea03724015185cd1ef585db2dad9be182cb19f1205e32b19abcc8ea3d96bd1ab4c85190255c682e5c190628b2bf19e2bd66e2903e4cf7146b
+  checksum: 8b3f1040e8ec006c9431508e73ef3f61cd5759bece3770189f7d52609f91bd156c9b18d0608f9cb14c456a1d1823be6633c573d5eee7cf9bd142b0f978c7a745
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-debug@npm:3.3.2"
+"@docusaurus/plugin-debug@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-debug@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils": 3.5.2
     fs-extra: ^11.1.1
     react-json-view-lite: ^1.2.0
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 043a025c160fb1cfb0149a8b939d0b8c54e2e79754fba5430112f476dc5f21650de54df8bab7bbf55f4677b914b5e115df8c24d6e2aca08345d54fd3784d1336
+  checksum: a839e6c3a595ea202fdd7fbce638ab8df26ba73a8c7ead8c04d1bbb509ebe34e9633e7fe9eb54a7a733e93a03d74a60df4d9f6597b9621ff464280d4dd71db34
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-google-analytics@npm:3.3.2"
+"@docusaurus/plugin-google-analytics@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-google-analytics@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: a472f5c94114a298b73e39cda5ba09dde0cc00e85943de7dbb9294ddc650e33bc7ce9999df7946b9f56488cb1843393c389c95c5958ce3a36a366dc663046641
+  checksum: 0b8c4d21333d40c2509d6ef807caaf69f085010c5deac514ab34f53b5486fd76766c90213dc98976a6c4d66fdfa14bf6b05594e51e8a53ec60c2a3fa08fd9a83
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-google-gtag@npm:3.3.2"
+"@docusaurus/plugin-google-gtag@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-google-gtag@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     "@types/gtag.js": ^0.0.12
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 8597cc183ce7432af0aeedfb1bc042f41c6a2b87b6968dd8ce0767419b4088e02e96fd3c1710e74821404155a04627907182a11f31a5dc4f525a4a4ed8593196
+  checksum: 5d53c2483c8c7e3a8e842bd091a774d4041f0e165d216b3c02f031a224a77258c9456e8b2acd0500b4a0eff474a83c1b82803628db9d4b132514409936c68ac4
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-tag-manager@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.3.2"
+"@docusaurus/plugin-google-tag-manager@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 9df287d72e0c56fea6fb1ffca0bf32423a91736ce95c79e52575295aafd0a5422463672b4ca9cbb185d220526756422ead477dc2bedb57230f73a853cba8f28d
+  checksum: 9a6fc2ca54ea677c6edfd78f4f392d7d9ae86afd085fcda96d5ac41efa441352c25a2519595d9d15fb9b838e2ae39837f0daf02e2406c5cd56199ae237bd7b7a
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-ideal-image@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-ideal-image@npm:3.3.2"
+"@docusaurus/plugin-ideal-image@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-ideal-image@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/lqip-loader": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/lqip-loader": 3.5.2
     "@docusaurus/responsive-loader": ^1.7.0
-    "@docusaurus/theme-translations": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/theme-translations": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     "@slorber/react-ideal-image": ^0.0.12
     react-waypoint: ^10.3.0
     sharp: ^0.32.3
@@ -3948,51 +3952,51 @@ __metadata:
   peerDependenciesMeta:
     jimp:
       optional: true
-  checksum: a8ae22ba85176460e86bdddc65c8be36278e9ed9681a0cae9eb78029549ea1869746b73e04bf3ef3294fad8bb421ad72eef4d9327063c424a47b9fac41505272
+  checksum: 037d38bfffe6719552c7bdc514820b9c68871400ff114a651a690a33377878f98c5841fc57b9cdc5436f520b7bcdc88eb839ef9e29b87be8670572c8f0fbe030
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/plugin-sitemap@npm:3.3.2"
+"@docusaurus/plugin-sitemap@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/plugin-sitemap@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/logger": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-common": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/logger": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-common": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     fs-extra: ^11.1.1
     sitemap: ^7.1.1
     tslib: ^2.6.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 65f813901476c81e94003e87f839c2e85d9662808215f0148a2aad39da2b97f43ab213543e5d40221bfb71e642b953e39601447d92f294a437b390e20c556ab4
+  checksum: 26b6bceb7ab87fe7f6f666742d1e81de32cdacc5aaa3d45d91002c7d64e3258f3d0aac87c6b0d442eaf34ede2af4b7521b50737f2e8e2718daff6fce10230213
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/preset-classic@npm:3.3.2"
+"@docusaurus/preset-classic@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/preset-classic@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/plugin-content-blog": 3.3.2
-    "@docusaurus/plugin-content-docs": 3.3.2
-    "@docusaurus/plugin-content-pages": 3.3.2
-    "@docusaurus/plugin-debug": 3.3.2
-    "@docusaurus/plugin-google-analytics": 3.3.2
-    "@docusaurus/plugin-google-gtag": 3.3.2
-    "@docusaurus/plugin-google-tag-manager": 3.3.2
-    "@docusaurus/plugin-sitemap": 3.3.2
-    "@docusaurus/theme-classic": 3.3.2
-    "@docusaurus/theme-common": 3.3.2
-    "@docusaurus/theme-search-algolia": 3.3.2
-    "@docusaurus/types": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/plugin-content-blog": 3.5.2
+    "@docusaurus/plugin-content-docs": 3.5.2
+    "@docusaurus/plugin-content-pages": 3.5.2
+    "@docusaurus/plugin-debug": 3.5.2
+    "@docusaurus/plugin-google-analytics": 3.5.2
+    "@docusaurus/plugin-google-gtag": 3.5.2
+    "@docusaurus/plugin-google-tag-manager": 3.5.2
+    "@docusaurus/plugin-sitemap": 3.5.2
+    "@docusaurus/theme-classic": 3.5.2
+    "@docusaurus/theme-common": 3.5.2
+    "@docusaurus/theme-search-algolia": 3.5.2
+    "@docusaurus/types": 3.5.2
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: fe98e457990a8d3d9966247ca02ad4f960aea0c9200e76ee1180942daea8165352dfa12b52bf3d8bd1ad89c16e849b36170f584aef838f16aaf3daab26ebbb3f
+  checksum: ec578e62b3b13b1874b14235a448a913c2d2358ea9b9d9c60bb250be468ab62387c88ec44e1ee82ad5b3d7243306e31919888a80eae62e5e8eab0ae12194bf69
   languageName: node
   linkType: hard
 
@@ -4013,26 +4017,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/theme-classic@npm:3.3.2"
+"@docusaurus/theme-classic@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/theme-classic@npm:3.5.2"
   dependencies:
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/mdx-loader": 3.3.2
-    "@docusaurus/module-type-aliases": 3.3.2
-    "@docusaurus/plugin-content-blog": 3.3.2
-    "@docusaurus/plugin-content-docs": 3.3.2
-    "@docusaurus/plugin-content-pages": 3.3.2
-    "@docusaurus/theme-common": 3.3.2
-    "@docusaurus/theme-translations": 3.3.2
-    "@docusaurus/types": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-common": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/mdx-loader": 3.5.2
+    "@docusaurus/module-type-aliases": 3.5.2
+    "@docusaurus/plugin-content-blog": 3.5.2
+    "@docusaurus/plugin-content-docs": 3.5.2
+    "@docusaurus/plugin-content-pages": 3.5.2
+    "@docusaurus/theme-common": 3.5.2
+    "@docusaurus/theme-translations": 3.5.2
+    "@docusaurus/types": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-common": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     "@mdx-js/react": ^3.0.0
     clsx: ^2.0.0
     copy-text-to-clipboard: ^3.2.0
-    infima: 0.2.0-alpha.43
+    infima: 0.2.0-alpha.44
     lodash: ^4.17.21
     nprogress: ^0.2.0
     postcss: ^8.4.26
@@ -4045,21 +4049,18 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: af3e6ede0574fba04e44560a6126ab380ab21e32ee13482cf4f21230818d58f3e794ff5ac9e715091612ff5f52561c3fcc8c59e3a69c75b663b70e00ffdfadbe
+  checksum: 6c415b01ad24bb43eb166e2b780a84356ff14a627627f6a541c2803832d56c4f9409a5636048693d2d24804f59c2cc7bda925d9ef999a8276fe125477d2b2e1e
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/theme-common@npm:3.3.2"
+"@docusaurus/theme-common@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/theme-common@npm:3.5.2"
   dependencies:
-    "@docusaurus/mdx-loader": 3.3.2
-    "@docusaurus/module-type-aliases": 3.3.2
-    "@docusaurus/plugin-content-blog": 3.3.2
-    "@docusaurus/plugin-content-docs": 3.3.2
-    "@docusaurus/plugin-content-pages": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-common": 3.3.2
+    "@docusaurus/mdx-loader": 3.5.2
+    "@docusaurus/module-type-aliases": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-common": 3.5.2
     "@types/history": ^4.7.11
     "@types/react": "*"
     "@types/react-router-config": "*"
@@ -4069,24 +4070,25 @@ __metadata:
     tslib: ^2.6.0
     utility-types: ^3.10.0
   peerDependencies:
+    "@docusaurus/plugin-content-docs": "*"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: b88ebf0cdeabdb766f98179d5ba4f54fddb24a3db6e498d01eeadf6d59c5f2d83588f30075551076f171a78ea9704f398d64e06d2af625f3232d7f261c90af10
+  checksum: c78ec7f6035abc920a2a0bc1ad78920178a5452538a3a70794eca8d4b976725f6ccc464ee3092afd31ca59b4e061ad4c21cdce7f5e10b06567075814b2fc2002
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/theme-search-algolia@npm:3.3.2"
+"@docusaurus/theme-search-algolia@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/theme-search-algolia@npm:3.5.2"
   dependencies:
     "@docsearch/react": ^3.5.2
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/logger": 3.3.2
-    "@docusaurus/plugin-content-docs": 3.3.2
-    "@docusaurus/theme-common": 3.3.2
-    "@docusaurus/theme-translations": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-validation": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/logger": 3.5.2
+    "@docusaurus/plugin-content-docs": 3.5.2
+    "@docusaurus/theme-common": 3.5.2
+    "@docusaurus/theme-translations": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-validation": 3.5.2
     algoliasearch: ^4.18.0
     algoliasearch-helper: ^3.13.3
     clsx: ^2.0.0
@@ -4098,23 +4100,23 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 1a922620399d69199ef2e32bded18b11ff2b1e5f93d074b46489052cab8e1f70d2c975b033bf74712756b051351b57807caae7630ed19d28de333a9fd02304e8
+  checksum: e945e3001996477597bfad074eaef074cf4c5365ed3076c3109130a2252b266e4e2fac46904a0626eedeff23b9ac11e7b985cc71f5485ede52d3ddf379b7959b
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-translations@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/theme-translations@npm:3.3.2"
+"@docusaurus/theme-translations@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/theme-translations@npm:3.5.2"
   dependencies:
     fs-extra: ^11.1.1
     tslib: ^2.6.0
-  checksum: a20ba46d36a7ac10d43ac0bc66ab3e137dd7d9529d26eee76513366f9fa7ae6fde61a85ce304c88bfa39136a90ffd53ee18358efd338a33e462999861bb01cdc
+  checksum: dc523c74a13fb8552c03e547c6de1c21881d899cc74bf088a2bed716e0ef1a4ceba2726c43656d87fff60413ca191f5ea946b182e4ae4129c14da832b5194d82
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/types@npm:3.3.2"
+"@docusaurus/types@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/types@npm:3.5.2"
   dependencies:
     "@mdx-js/mdx": ^3.0.0
     "@types/history": ^4.7.11
@@ -4128,13 +4130,13 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 6da53038547d94cf5e2a8b14224972f83e1779e45453fcaf237e4e2b5f4c380534a04332cfa2029ceaae72e3d4a93a544d2b07c0bd280a365cb2b77516620628
+  checksum: e39451b7b08673ad5e1551ee6e4286f90f2554cf9ba245abfa56670550f48afca9c57b01c10ffa21dacb734c0fcd067150eeb2b1c1ebb1692f1f538b1eed0029
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/utils-common@npm:3.3.2"
+"@docusaurus/utils-common@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/utils-common@npm:3.5.2"
   dependencies:
     tslib: ^2.6.0
   peerDependencies:
@@ -4142,30 +4144,32 @@ __metadata:
   peerDependenciesMeta:
     "@docusaurus/types":
       optional: true
-  checksum: cb745c0b912babee39a78bbf592cc622b35de9044bc5b99a8b59fad1e278ef447b03aac39a18d6112a74d9053f04ab9ec4b3d2f2bc77014a8dd6d212e4e48b21
+  checksum: 9d550c89663d4271456ae0832c82a1691207ccc95e21df3a05a4bd6bbd2624bb9e3ab7327d939c04b2023378987bcf99321b2c37be1af214852832f65d6db14a
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/utils-validation@npm:3.3.2"
+"@docusaurus/utils-validation@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/utils-validation@npm:3.5.2"
   dependencies:
-    "@docusaurus/logger": 3.3.2
-    "@docusaurus/utils": 3.3.2
-    "@docusaurus/utils-common": 3.3.2
+    "@docusaurus/logger": 3.5.2
+    "@docusaurus/utils": 3.5.2
+    "@docusaurus/utils-common": 3.5.2
+    fs-extra: ^11.2.0
     joi: ^17.9.2
     js-yaml: ^4.1.0
+    lodash: ^4.17.21
     tslib: ^2.6.0
-  checksum: 2635d233a34919bb8a2970eec63cbf79788104e7c821d63488c6c1ed466b450019ffa640ddd6d0560b99f17829275c9735de6fc0154ad2e2de5d841083a852c1
+  checksum: 5966e6d0e8f26292c629899f13b545501b53b345b0e2291bb47aaa80d7c9c5cf155e15a4ecd073a4095ee7c83c6db3612e0a34f81a8187fd20410b1aeb92d731
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@docusaurus/utils@npm:3.3.2"
+"@docusaurus/utils@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@docusaurus/utils@npm:3.5.2"
   dependencies:
-    "@docusaurus/logger": 3.3.2
-    "@docusaurus/utils-common": 3.3.2
+    "@docusaurus/logger": 3.5.2
+    "@docusaurus/utils-common": 3.5.2
     "@svgr/webpack": ^8.1.0
     escape-string-regexp: ^4.0.0
     file-loader: ^6.2.0
@@ -4182,13 +4186,14 @@ __metadata:
     shelljs: ^0.8.5
     tslib: ^2.6.0
     url-loader: ^4.1.1
+    utility-types: ^3.10.0
     webpack: ^5.88.1
   peerDependencies:
     "@docusaurus/types": "*"
   peerDependenciesMeta:
     "@docusaurus/types":
       optional: true
-  checksum: 5757e9cb7d70a5b9fbb2a6cde6b66e36b335b77a2349eaa88c3dca5819ac680d5491b2df992223f3ae7fb6ffeb957f6929a9145fd6f154c761c89536450d745c
+  checksum: 0e0f4fc65ed076d4e4b551ecb61447b7c2468060d1655afff314515844ae34dc0546f467f53bff535f3144afc109e974da27fadb7c678a5d19966bed9e7a27c4
   languageName: node
   linkType: hard
 
@@ -6907,7 +6912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:^1.0.0-rc.12, cheerio@npm:^1.0.0-rc.9":
+"cheerio@npm:1.0.0-rc.12, cheerio@npm:^1.0.0-rc.9":
   version: 1.0.0-rc.12
   resolution: "cheerio@npm:1.0.0-rc.12"
   dependencies:
@@ -9058,7 +9063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.1.1":
+"fs-extra@npm:^11.1.1, fs-extra@npm:^11.2.0":
   version: 11.2.0
   resolution: "fs-extra@npm:11.2.0"
   dependencies:
@@ -10004,10 +10009,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"infima@npm:0.2.0-alpha.43":
-  version: 0.2.0-alpha.43
-  resolution: "infima@npm:0.2.0-alpha.43"
-  checksum: fc5f79240e940eddd750439511767092ccb4051e5e91d253ec7630a9e7ce691812da3aa0f05e46b4c0a95dbfadeae5714fd0073f8d2df12e5aaff0697a1d6aa2
+"infima@npm:0.2.0-alpha.44":
+  version: 0.2.0-alpha.44
+  resolution: "infima@npm:0.2.0-alpha.44"
+  checksum: e9871f4056c0c8b311fcd32e2864d23a8f6807af5ff32d3c4d8271ad9971b5a7ea5016787a6b215893bb3e9f5f14326816bc05151d576dd375b0d79279cdfa8b
   languageName: node
   linkType: hard
 
@@ -14485,11 +14490,11 @@ __metadata:
   resolution: "solus-help-center@workspace:."
   dependencies:
     "@cmfcmf/docusaurus-search-local": ^1.2.0
-    "@docusaurus/core": 3.3.2
-    "@docusaurus/eslint-plugin": ^3.3.2
-    "@docusaurus/module-type-aliases": ^3.3.2
-    "@docusaurus/plugin-ideal-image": 3.3.2
-    "@docusaurus/preset-classic": 3.3.2
+    "@docusaurus/core": 3.5.2
+    "@docusaurus/eslint-plugin": 3.5.2
+    "@docusaurus/module-type-aliases": 3.5.2
+    "@docusaurus/plugin-ideal-image": 3.5.2
+    "@docusaurus/preset-classic": 3.5.2
     "@emotion/react": ^11.11.1
     "@emotion/styled": ^11.11.0
     "@mdx-js/react": ^3.0.0


### PR DESCRIPTION
## Description

Update Docusaurus to 3.5.2

Release notes:
[3.4.0](https://docusaurus.io/changelog/3.4.0)
[3.5.0](https://docusaurus.io/changelog/3.5.0)
[3.5.1](https://docusaurus.io/changelog/3.5.1)
[3.5.2](https://docusaurus.io/changelog/3.5.2)

Test Plan: Browsed through all the pages of the Help Center and didn't notice any inconsistencies

This enables some neat new features like author pages (resp. an author**s** page) for the Dev Log (incoming PR)

