### PR TITLE
Dev Log: Enable author pages

### DIFF
--- a/devlog/authors.yml
+++ b/devlog/authors.yml
@@ -1,7 +1,7 @@
 joey:
   name: Joey Riches
   title: Solus Staff
-  url: https://github.com/joebonrichie
+  page: true
   image_url: https://avatars.githubusercontent.com/u/5338090?s=400&u=f77ed45c7e83814ce3e8bd199fc293bd5b53682b&v=4
   socials:
     github: joebonrichie
@@ -9,7 +9,7 @@ joey:
 david:
   name: David Harder
   title: Solus Staff
-  url: https://github.com/davidjharder
+  page: true
   image_url: https://avatars.githubusercontent.com/u/23007135?v=4
   socials:
     github: davidjharder


### PR DESCRIPTION
## Description

Depends on #563 (Docusaurus >= 3.5.0)

This enables pages for single authors (showing their posts) and an author index page for the Dev Log (showing all authors and number of their posts)

Note: Replaced the GitHub URL in the author profiles because a click on the author will now lead to the autor page instead, and the GitHub profile is linked via the socials

Authors index page:
![](https://i.imgur.com/Eg8dT1F.png)

Single author page:
![](https://i.imgur.com/AzTY4p0.png)
