### PR TITLE
devlog: Add Migrating to Python3 post

### DIFF
--- a/devlog/2024-10-06-eopkg-is-dead-redux.md
+++ b/devlog/2024-10-06-eopkg-is-dead-redux.md
@@ -1,0 +1,14 @@
+---
+title: Migrating eopkg to python3
+description: The travails of backwards and forwards compatibility efforts
+slug: migrating-eopkg-to-python3
+authors: ermo
+tags: [eopkg, devlog, solus]
+---
+
+As part of our efforts to migrate the Solus `eopkg` package manager from Python2 to Python3, we are fixing up old eopkg Python2 code.
+
+This post details what we have been working on up until now.
+
+<!-- truncate -->
+


### PR DESCRIPTION
## Description

This is intended to be an overview of the work we have had to complete on the eopkg Python2 code base in order to prepare to switching fully to the eopkg Python3 code base.