### PR TITLE
package.yml: Use fixed tag reference for CONFOPTS link

### DIFF
--- a/docs/packaging/package.yml.md
+++ b/docs/packaging/package.yml.md
@@ -257,7 +257,7 @@ BOLT is a post-link optimizer developed to speed up large applications. You will
 | **%ARCH%**                   | Indicates the current build architecture.                                                                                                         |
 | **%CC%**                     | C compiler.                                                                                                                                       |
 | **%CFLAGS%**                 | cflags as set in `eopkg.conf`.                                                                                                                    |
-| **%CONFOPTS%**               | Flags / options for configuration, such as `--prefix=%PREFIX%`. [Full List.](https://github.com/getsolus/ypkg/blob/master/ypkg2/rc.yml#L444-L456) |
+| **%CONFOPTS%**               | Flags / options for configuration, such as `--prefix=%PREFIX%`. [Full List.](https://github.com/getsolus/ypkg/blob/v33/ypkg2/rc.yml#L446-L458)    |
 | **%CXX%**                    | C++ compiler.                                                                                                                                     |
 | **%CXXFLAGS%**               | cxxflags as set in `eopkg.conf`.                                                                                                                  |
 | **%JOBS%**                   | jobs, as set in `eopkg.conf`.                                                                                                                     |


### PR DESCRIPTION
## Description

Use a fixed tag reference (the now latest release/tag v33) for the link to the CONFOPTS in `ypkg`, so it doesn't constantly move in this file that gets updated regularly. The CONFOPTS themselves are relatively stable, so the link only really has to be updated once every blue moon when these movements through unrelated changes are eliminated

Note: haven't included the `yarn prettier` changes because they lead to a lot of noise relative to the size of the actual change (and touch a file that is completely unrelated; the footer). I can include it, but it's probably better done separately.