### PR TITLE
snap.md: Update warning with deprecation date

### DIFF
--- a/docs/user/software/third-party/snap.md
+++ b/docs/user/software/third-party/snap.md
@@ -6,8 +6,8 @@ summary: Working with snaps
 # Snap
 
 :::warning
-Note that snaps are going to be [removed from Solus in the future][2],
-and are not fully confined in Solus with Linux 6.9 and newer.
+Snaps will be [**removed from Solus in early January 2025**][2],
+and are not fully confined in Solus with Linux kernel 6.9 and newer.
 See the section on confinement below.
 :::
 


### PR DESCRIPTION
- Update the warning on the snap page to include a date for deprecation. I avoid a precise date because we cannot say exactly when the change will be synced to stable
- Change the wording slightly to my preferred style

![Capture](https://github.com/user-attachments/assets/d7bc5312-8207-4c16-84ce-1cd94ac6d7ea)

