### PR TITLE
bugfix: correct helper setup docs for bash and zsh

### DIFF
--- a/docs/packaging/prepare-for-packaging.md
+++ b/docs/packaging/prepare-for-packaging.md
@@ -148,9 +148,8 @@ If you already have a customized `.zshrc` or config for `zsh`, you'll need to ad
 ```bash
 mkdir -p ~/.zshrc.d
 chmod 700 ~/.zshrc.d
-cat <<eos >>! ~/.testrc
+cat <<eos >>! ~/.zshrc
 fpath=(\$HOME/.zshrc.d \$fpath)
-autoload -U \$HOME/.zshrc.d/*
 source \$HOME/.zshrc.d/solus-monorepo-helpers.zsh
 
 eos

--- a/docs/packaging/prepare-for-packaging.md
+++ b/docs/packaging/prepare-for-packaging.md
@@ -141,15 +141,20 @@ ln -s ~/solus-packages/common/Scripts/helpers.fish ~/.config/fish/conf.d/solus.f
 
 :::note
 
-If you already have a customized `.zshrc` or config for `zsh`, you'll need to adapt these commands or edit your config by hand
+If you already have a customized `.zshrc` or config for `zsh`, you'll need to adapt these commands or edit your config by hand (e.g. instead of using the `cat` command)
 
 :::
 
 ```bash
 mkdir -p ~/.zshrc.d
 chmod 700 ~/.zshrc.d
-printf "\nfpath=(~/.zshrc.d \$fpath)" >> ~/.zshrc
-ln -s ~/solus-packages/common/Scripts/helpers.zsh ~/.zshrc.d/solus-monorepo-helpers.zsh
+cat <<eos >>! ~/.testrc
+fpath=(\$HOME/.zshrc.d \$fpath)
+autoload -U \$HOME/.zshrc.d/*
+source \$HOME/.zshrc.d/solus-monorepo-helpers.zsh
+
+eos
+
 source ~/.zshrc
 ```
 
@@ -164,6 +169,7 @@ You may have more than what is shown here if you have customized things
 ```bash
 fpath=($HOME/.zshrc.d $fpath)
 autoload -U $HOME/.zshrc.d/*
+source $HOME/.zshrc.d/solus-monorepo-helpers.zsh
 ```
 
 Verify that `$fpath` contains the needed directory with:

--- a/docs/packaging/prepare-for-packaging.md
+++ b/docs/packaging/prepare-for-packaging.md
@@ -3,7 +3,6 @@ title: Prepare for Packaging
 summary: Quick guide on getting your system set up for packaging on Solus
 sidebar_position: 1
 ---
-
 # Prepare for packaging
 
 ## Switch to the Unstable repository
@@ -120,8 +119,16 @@ After cloning your repository, create a symlink to source the helper functions f
 
 ```bash
 mkdir -p ~/.bashrc.d
+chmod 700 ~/.bashrc.d
 ln -s ~/solus-packages/common/Scripts/helpers.sh ~/.bashrc.d/solus-monorepo-helpers.sh
+source ~/.bashrc
 ```
+
+:::note
+
+By default, the system will load all files in `~/.bashrc.d` through code in `.bashrc`
+
+:::
 
 ### fish
 
@@ -132,25 +139,52 @@ ln -s ~/solus-packages/common/Scripts/helpers.fish ~/.config/fish/conf.d/solus.f
 
 ### zsh
 
+:::note
+
+If you already have a customized `.zshrc` or config for `zsh`, you'll need to adapt these commands or edit your config by hand
+
+:::
+
 ```bash
 mkdir -p ~/.zshrc.d
+chmod 700 ~/.zshrc.d
 printf "\nfpath=(~/.zshrc.d \$fpath)" >> ~/.zshrc
-source ~/.zshrc
 ln -s ~/solus-packages/common/Scripts/helpers.zsh ~/.zshrc.d/solus-monorepo-helpers.zsh
+source ~/.zshrc
+```
+
+This is what you need in your `.zshrc` (or another file loaded by `zsh`)
+
+:::note
+
+You may have more than what is shown here if you have customized things
+
+:::
+
+```bash
+fpath=($HOME/.zshrc.d $fpath)
+autoload -U $HOME/.zshrc.d/*
+```
+
+Verify that `$fpath` contains the needed directory with:
+
+```bash
+echo $fpath | grep .zshrc.d
 ```
 
 ---
 
 You should now have the following available from your shell:
 
-| Function          | Description                                                                                                                                   | Usage                         |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| **cpesearch**     | Search for CPE Names for packages. For use when writing the [`monitoring.yml`](/docs/packaging/monitoring.yml.md) file for a package          | `cpesearch search-term`       |
-| **goroot**        | When in the Solus packages repository, change directory to the root directory.                                                                | `goroot`                      |
-| **gotopkg**       | Change directory to any Solus package. You can type part of the package name then double press `Tab` to get autocompletion for this function. | `gotopkg firefox`             |
-| **gotosoluspkgs** | Change directory to the Solus packages repository from anywhere on the filesystem.                                                            | `gotosoluspkgs`               |
-| **whatprovides**  | Find out what package provides a library by reading the `abi_libs` files.                                                                     | `whatprovides libfoobar.so.1` |
-| **whatuses**      | Find out what packages use a library by reading the `abi_used_libs` files.                                                                    | `whatuses libfoobar.so.1`     |
+
+| Function          | Description                                                                                                                                  | Usage                         |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **cpesearch**     | Search for CPE Names for packages. For use when writing the[`monitoring.yml`](/docs/packaging/monitoring.yml.md) file for a package          | `cpesearch search-term`       |
+| **goroot**        | When in the Solus packages repository, change directory to the root directory.                                                               | `goroot`                      |
+| **gotopkg**       | Change directory to any Solus package. You can type part of the package name then double press`Tab` to get autocompletion for this function. | `gotopkg firefox`             |
+| **gotosoluspkgs** | Change directory to the Solus packages repository from anywhere on the filesystem.                                                           | `gotosoluspkgs`               |
+| **whatprovides**  | Find out what package provides a library by reading the`abi_libs` files.                                                                     | `whatprovides libfoobar.so.1` |
+| **whatuses**      | Find out what packages use a library by reading the`abi_used_libs` files.                                                                    | `whatuses libfoobar.so.1`     |
 
 ## Building packages
 


### PR DESCRIPTION
## Description

Fix instructions for zsh and bash so helper functions work Add note that people with custom zsh configs need to adapt instructions Add example of what zshrc should contain

Fixes #576

## Testing

Verified solus helper commands can be run in a new shell session for both bash and zsh
For zsh, also created a test file in `~/.zshrc.d` and verified it was able to be run without specifying the path
