### PR TITLE
Update command to go to TTY

### DIFF
--- a/docs/user/troubleshooting/index.md
+++ b/docs/user/troubleshooting/index.md
@@ -56,7 +56,7 @@ If booting into the previous kernel doesn't solve the issue, there may be an iss
 
 ## Boot failure
 
-If Solus partially boots, you can generally get to a TTY using `Ctrl+Alt+F2` to login and be able to run commands just like using a terminal. This enables you to run some commands to identify or resolve the issue.
+If Solus partially boots, you can generally get to a TTY using `Ctrl+Alt+F3` to login and be able to run commands just like using a terminal. This enables you to run some commands to identify or resolve the issue.
 
 ### Display manager won't start
 


### PR DESCRIPTION
## Description

The command to get to a TTY had been written as `Ctrl+Alt+F2`. This won't work on Plasma Wayland. It brings up a weird pseudo UI. F3 should work for all DEs.
