### PR TITLE
Update Mastodon links for new Mastodon account

### DIFF
--- a/docs/user/contributing/getting-involved.md
+++ b/docs/user/contributing/getting-involved.md
@@ -36,7 +36,7 @@ You will find the following Solus rooms on the `matrix.org` homeserver:
 Alongside the forums, you can communicate with developers or others in the community by using one of the following websites:
 
 - [Facebook](https://www.facebook.com/get.solus)
-- [Mastodon](https://fosstodon.org/@Solus)
+- [Mastodon](https://floss.social/@getsolus)
 - [Reddit](https://www.reddit.com/r/SolusProject/)
 
 ## Funding

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -135,7 +135,7 @@ const config = {
               },
               {
                 label: "Mastodon",
-                href: "https://fosstodon.org/@Solus",
+                href: "https://floss.social/@getsolus",
               },
               {
                 label: "Github",
@@ -201,7 +201,7 @@ const config = {
               },
               {
                 label: "Mastodon",
-                href: "https://fosstodon.org/@Solus",
+                href: "https://floss.social/@getsolus",
                 rel: "me",
               },
             ],

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -41,7 +41,7 @@
   },
   "link.item.label.Mastodon": {
     "message": "Mastodon",
-    "description": "The label of footer link with label=Mastodon linking to https://fosstodon.org/@Solus"
+    "description": "The label of footer link with label=Mastodon linking to https://floss.social/@getsolus"
   },
   "link.item.label.SolusHomepage": {
     "message": "Solus Homepage",


### PR DESCRIPTION
## Description

Update Mastodon links to point to new account.

Fixes https://github.com/getsolus/help-center-docs/issues/618
