### PR TITLE
Re-organize "Boot management"

### DIFF
--- a/docs/user/quick-start/boot-management.md
+++ b/docs/user/quick-start/boot-management.md
@@ -1,63 +1,65 @@
 ---
-title: Boot Management
+title: Boot management
 summary: Guide to customizing the Solus boot process
 ---
 
-# Boot Management
+Solus uses `clr-boot-manager` from the Clear Linux project to handle all boot configuration. This tool automatically configures the appropriate boot loader based on your system type:
 
-## clr-boot-manager
+- Legacy BIOS systems: GRUB2
+- Modern UEFI systems: `systemd-boot`
 
-Solus leverages `clr-boot-manager` from the Clear Linux\* project to manage its boot process.
-On legacy BIOS systems, `clr-boot-manager` will configure `GRUB2` to properly boot your system.  
-On modern UEFI systems, `clr-boot-manager` will configure `systemd-boot` instead.  
-This means that any time we want to modify the boot process, `clr-boot-manager` will be involved.  
-Trying to modify the configurations manually may work temporarily, but will be overwritten eventually.
+Because `clr-boot-manager` manages these configurations, any boot customizations must go through this tool rather than manual edits. If you try to modify the configurations manually, `clr-boot-manager` will overwrite your changes during the next system update.
 
-### Open the boot menu
+## Access the boot menu
 
-By default, EFI installs will not show the boot menu and boot directly into Solus. By hitting space bar (repeatedly) during boot, the boot menu will appear (it may take a couple of goes to get the timing right).
+On systems with UEFI installations, the boot menu doesn't appear by default. To display the boot menu:
 
-### Displaying the boot menu by default every boot
+- Press the <kbd>Spacebar</kbd> key repeatedly as your computer starts. You may need several attempts to get the timing right.
 
-The following command will set the timeout of the boot loader to five seconds so that it appears by default:
+## Display the boot menu by default
 
-```bash
-sudo clr-boot-manager set-timeout 5 && sudo clr-boot-manager update
-```
+To make the boot menu appear automatically with a five-second timeout:
 
-### Adding kernel parameters
+- Run the following command:
 
-Kernel parameters can be appended to boot via creating a file for `clr-boot-manager` to use when updating kernels. For example, to add `nomodeset` to boot options, you would create a file in `/etc/kernel/cmdline.d` (as sudo):
+  ```bash
+  sudo clr-boot-manager set-timeout 5 && sudo clr-boot-manager update
+  ```
 
-```bash
-sudo mkdir -p /etc/kernel/cmdline.d
-echo 'nomodeset' | sudo tee /etc/kernel/cmdline.d/40_nomodeset.conf
-```
+## Add kernel parameters
 
-The settings should be on one line with a space between them. You will need to run `sudo clr-boot-manager update` for the options to be appended to boot.
+You can add kernel parameters by creating configuration files that `clr-boot-manager` uses when updating kernels. 
 
-## Kernels
+To add kernel parameters, do the following:
 
-### Installing a different kernel branch
+1. Create the configuration directory:
 
-By default, Solus utilizes our linux-current kernel. The separate kernel branches can be added by installing the `linux-lts` or `linux-current` packages. Note that each kernel has separate module packages, so if you use these kernel modules, you'll need to install the one related to the kernel you are adding.
+   ```bash
+   sudo mkdir -p /etc/kernel/cmdline.d
+   ```
 
-| linux-lts               | linux-current                   |
-| ----------------------- | ------------------------------- |
-| bbswitch                | bbswitch-current                |
-| broadcom-sta            | broadcom-sta-current            |
-| linux-lts-headers       | linux-current-headers           |
-| nvidia-470-glx-driver   | nvidia-470-glx-driver-current   |
-| nvidia-beta-driver      | nvidia-beta-driver-current      |
-| nvidia-developer-driver | nvidia-developer-driver-current |
-| nvidia-glx-driver       | nvidia-glx-driver-current       |
-| openrazer               | openrazer-current               |
-| rtl8852bu               | rtl8852bu-current               |
-| v4l2loopback            | v4l2loopback-current            |
-| vhba-module             | vhba-module-current             |
-| virtualbox              | virtualbox-current              |
-| xone                    | xone-current                    |
+1. Create a configuration file with your kernel parameter:
 
-### Change the default kernel branch to boot
+   ```bash
+   echo 'parameter-name' | sudo tee /etc/kernel/cmdline.d/40_[description].conf
+   ```
 
-After successfully booting into a kernel from the `current` or `lts` branches running `sudo clr-boot-manager update` will make the booted kernel branch the default boot option going forward.
+   For example, to add the `nomodeset` parameter:
+
+   ```bash
+   echo 'nomodeset' | sudo tee /etc/kernel/cmdline.d/40_nomodeset.conf
+   ```
+
+1. If you want to add multiple parameters, put them on one line with spaces between them in the configuration file. 
+
+   For example:
+
+   ```bash
+   echo 'nomodeset quiet splash acpi=off' | sudo tee /etc/kernel/cmdline.d/40_multiple_params.conf
+   ```
+
+1. Apply the new kernel parameters:
+
+   ```bash
+   sudo clr-boot-manager update
+   ```

--- a/docs/user/quick-start/kernel-management/_category_.json
+++ b/docs/user/quick-start/kernel-management/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Kernel management",
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/docs/user/quick-start/kernel-management/add-new-kernels.md
+++ b/docs/user/quick-start/kernel-management/add-new-kernels.md
@@ -1,0 +1,64 @@
+---
+title: Add a different kernel branch
+summary: Install and switch between kernel branches in Solus.
+---
+
+Solus offers two kernel types: the current kernel (`linux-current`) and the LTS (Long-Term Support) kernel (`linux-lts`).
+
+By default, Solus uses the `linux-current` kernel. You can switch between kernel branches at any time.
+
+To install and switch to a different kernel branch, follow these steps:
+
+1. Install the desired kernel branch:
+
+   - Current kernel
+
+     ```
+	  sudo eopkg install linux-current
+	  ```
+
+   - LTS kernel
+	 
+	  ```
+	  sudo eopkg install linux-lts
+	  ```
+
+1. Install the necessary kernel modules of the kernel branch you want to try.
+
+   Each kernel branch has its own set of module packages. If you use hardware or features that require specific kernel modules (for example, NVIDIA graphics cards or VirtualBox), you must also install the corresponding module package for the new kernel branch.
+
+   The following table lists the kernel modules of each branch:
+
+   | linux-lts               | linux-current                   |
+   | ----------------------- | ------------------------------- |
+   | bbswitch                | bbswitch-current                |
+   | broadcom-sta            | broadcom-sta-current            |
+   | linux-lts-headers       | linux-current-headers           |
+   | nvidia-470-glx-driver   | nvidia-470-glx-driver-current   |
+   | nvidia-beta-driver      | nvidia-beta-driver-current      |
+   | nvidia-developer-driver | nvidia-developer-driver-current |
+   | nvidia-glx-driver       | nvidia-glx-driver-current       |
+   | openrazer               | openrazer-current               |
+   | rtl8852bu               | rtl8852bu-current               |
+   | v4l2loopback            | v4l2loopback-current            |
+   | vhba-module             | vhba-module-current             |
+   | virtualbox              | virtualbox-current              |
+   | xone                    | xone-current                    |
+
+1. Restart your computer.
+
+1. Select the new kernel branch from the boot menu when your computer restarts.
+
+   :::warning Important
+
+   On systems with UEFI installations, the boot menu doesn't appear by default.
+   
+   To display the boot menu, press the <kbd>Spacebar</kbd> key repeatedly as your computer starts.
+
+   :::
+
+1. After you successfully boot with the new kernel, set it as the default to ensure Solus uses it for future startups:
+
+   ```
+   sudo clr-boot-manager update
+   ```

--- a/docs/user/quick-start/kernel-management/remove-old-kernels.md
+++ b/docs/user/quick-start/kernel-management/remove-old-kernels.md
@@ -1,0 +1,86 @@
+---
+title: Remove old kernels
+summary: Manage and remove old kernels to free up space on the boot partition.
+---
+You might need to remove old kernels for various reasons:
+
+- The boot partition is too small for multiple kernel versions
+- [`clr-boot-manager`](https://github.com/clearlinux/clr-boot-manager) not automatically cleaning up old entries
+- Custom or testing kernels installed that won't be automatically removed
+
+If the boot partition of your system is full, updates might fail and you might not be able to install new kernels.
+
+:::tip
+
+Keep at least 2-3 versions: your current kernel and the most recent previous version as a backup.
+
+:::
+
+To remove old kernels, do the following:
+
+1. Check which kernel you're currently running.
+
+   ```bash
+   uname -r
+   ```
+
+   This command displays the version of the currently running kernel. For example:
+   
+   ```
+   6.6.8-290.current
+   ```
+   
+   Make note of this version.
+
+1. Mount the boot partition.
+
+   ```bash
+   sudo clr-boot-manager mount-boot
+   ```
+
+1. Check the partition's usage.
+
+   ```bash
+   sudo du -d1 -h /boot
+   df -h
+   ```
+
+   The commands display the disk usage of directories in `/boot` in human-readable format, and show overall disk space usage including the boot partition.
+
+1. List the installed kernels.
+
+   ```bash
+   sudo clr-boot-manager list-kernels
+   ```
+
+   The command shows the installed kernels. For example:
+
+   ```
+   com.solus-project.current.6.6.8-290
+   com.solus-project.current.6.6.7-289
+   com.solus-project.current.6.6.6-288
+   ```
+
+1. Remove the kernels you don't need.
+
+   :::danger Warning
+   
+   Never remove the kernel your system is using. This is the version you noted in step 1.
+   
+   :::
+
+   ```bash
+   sudo clr-boot-manager remove-kernel <kernel-name>
+   ```
+
+   Replace `<kernel-name>` with the specific kernel version to remove. For example:
+
+   ```bash
+   sudo clr-boot-manager remove-kernel com.solus-project.current.6.6.6-288
+   ```
+
+1. Verify that space has been freed on the boot partition.
+
+   ```bash
+   df -h
+   ```


### PR DESCRIPTION
Fixes #624 (Check remove-old-kernels.md).

After reading the contents of the online help, I decided to add this in the "Quick Start" section rather than the "Troubleshooting" section for a couple reasons:

- The content is somewhat related to the procedure to switch between kernel branches.
- This procedure might not always be troubleshooting. Some users might do this as maintenance instead.

I added a tip at the beginning of the new topic ("Keep at least 2-3 versions: your current kernel and the most recent previous version as a backup."). Please have a look and let me know if it's accurate.

## Description
- Re-write boot-management.md to follow the style guide
- Create a new section: Kernel management
- Move the "Kernels" section of boot management to the new section
- Add "Remove old kernels" to the new section.


