### PR TITLE
add instructions for enabling numlock at login

### DIFF
--- a/docs/user/editions/budgie/tips-and-tricks.md
+++ b/docs/user/editions/budgie/tips-and-tricks.md
@@ -31,4 +31,19 @@ budgie-panel --reset --replace &
 
 After this you can press CTRL + D to close the terminal without closing the Budgie Panel process.
 
+## Enable Numlock at Login
+
+At the login screen on boot, numlock might not be enabled even if set in your BIOS / UEFI.
+
+To change this, you will need the `numlockx` and `lightdm-settings` packages:
+
+```
+sudo eopkg it numlockx lightdm-settings && sudo lightdm-settings
+```
+
+Numlock can then be enabled or disabled via a toggle switch on the _Settings_ tab:
+
+![image](https://github.com/user-attachments/assets/d613d863-9e83-47d2-830f-38d3cacba9b7)
+
+
 > TODO: There's got to be more that we can add here


### PR DESCRIPTION
## Description

My user password includes numbers, but by default Solus Budgie does not expose a setting to enable numlock at the login screen, nor does it honour the BIOS / UEFI setting on my computer. I found instructions for it on the Solus forums which work perfectly, so I thought they would be helpful to include in the _Tips and Tricks_ documentation.

Source: <https://discuss.getsol.us/d/5583-how-to-enable-numlock-in-login/13>