### PR TITLE
Update disks.md (EFI partition size)

### DIFF
--- a/docs/user/quick-start/installation/disks.md
+++ b/docs/user/quick-start/installation/disks.md
@@ -21,7 +21,7 @@ Alongside these options, we also provide the ability to use full-disk encryption
 
 If you are using a system with UEFI, you may need to create an EFI System Partition, also referred to as an ESP. This is not necessary if you are enabling Solus to install onto the entire disk.
 
-To create an EFI System Partition, open up GParted and create a FAT32 partition that is 1024 MiB in size. Next, right-click on the partition and click Manage Flags. On the Manage Flags section, enable the `boot` and `esp` flags.
+To create an EFI System Partition, open up GParted and create a FAT32 partition that is 1024&nbsp;MiB in size. Next, right-click on the partition and click Manage Flags. On the Manage Flags section, enable the `boot` and `esp` flags.
 
 **Notes:**
 

--- a/docs/user/quick-start/installation/disks.md
+++ b/docs/user/quick-start/installation/disks.md
@@ -21,7 +21,7 @@ Alongside these options, we also provide the ability to use full-disk encryption
 
 If you are using a system with UEFI, you may need to create an EFI System Partition, also referred to as an ESP. This is not necessary if you are enabling Solus to install onto the entire disk.
 
-To create an EFI System Partition, open up GParted and create a FAT32 partition that is 1&nbsp;GB in size. Next, right-click on the partition and click Manage Flags. On the Manage Flags section, enable the `boot` and `esp` flags.
+To create an EFI System Partition, open up GParted and create a FAT32 partition that is 1&nbsp;GiB (= 1024 MiB) in size. Next, right-click on the partition and click Manage Flags. On the Manage Flags section, enable the `boot` and `esp` flags.
 
 **Notes:**
 

--- a/docs/user/quick-start/installation/disks.md
+++ b/docs/user/quick-start/installation/disks.md
@@ -21,7 +21,7 @@ Alongside these options, we also provide the ability to use full-disk encryption
 
 If you are using a system with UEFI, you may need to create an EFI System Partition, also referred to as an ESP. This is not necessary if you are enabling Solus to install onto the entire disk.
 
-To create an EFI System Partition, open up GParted and create a FAT32 partition that is 1&nbsp;GiB (= 1024 MiB) in size. Next, right-click on the partition and click Manage Flags. On the Manage Flags section, enable the `boot` and `esp` flags.
+To create an EFI System Partition, open up GParted and create a FAT32 partition that is 1024 MiB in size. Next, right-click on the partition and click Manage Flags. On the Manage Flags section, enable the `boot` and `esp` flags.
 
 **Notes:**
 

--- a/docs/user/quick-start/installation/disks.md
+++ b/docs/user/quick-start/installation/disks.md
@@ -21,7 +21,7 @@ Alongside these options, we also provide the ability to use full-disk encryption
 
 If you are using a system with UEFI, you may need to create an EFI System Partition, also referred to as an ESP. This is not necessary if you are enabling Solus to install onto the entire disk.
 
-To create an EFI System Partition, open up GParted and create a FAT32 partition that is 1024&nbsp;MiB in size. Next, right-click on the partition and click Manage Flags. On the Manage Flags section, enable the `boot` and `esp` flags.
+To create an EFI System Partition, open up GParted and create a FAT32 partition that is 2048&nbsp;MiB in size. Next, right-click on the partition and click Manage Flags. On the Manage Flags section, enable the `boot` and `esp` flags.
 
 **Notes:**
 

--- a/docs/user/quick-start/installation/system-requirements.md
+++ b/docs/user/quick-start/installation/system-requirements.md
@@ -6,7 +6,7 @@ summary: Hardware Requirements Guide
 # System requirements
 
 - A blank DVD or a USB drive that is at least 3&nbsp;GB
-- On UEFI systems, an EFI partition of 1&nbsp;GB minimum
+- On [UEFI](disks.md/#uefi) systems, an EFI partition of 1&nbsp;GiB minimum
 - An internet connection
 - System connected to AC power
 

--- a/docs/user/quick-start/installation/system-requirements.md
+++ b/docs/user/quick-start/installation/system-requirements.md
@@ -6,7 +6,7 @@ summary: Hardware Requirements Guide
 # System requirements
 
 - A blank DVD or a USB drive that is at least 3&nbsp;GB
-- On [UEFI](disks.md/#uefi) systems, an EFI partition of 1&nbsp;GiB minimum
+- On [UEFI](disks.md/#uefi) systems, an EFI partition of 2&nbsp;GiB minimum
 - An internet connection
 - System connected to AC power
 


### PR DESCRIPTION
change 1 GB EFI partition size recommendation to 1 GiB (= 1024 MiB) as is Calamares requirement

## Description

This pull request modifies disks.md to adjust Efi size recommendation from `1 GB` to `1 GiB (= 1024 MiB)` to comply with Calamares requirements.

This solves [#643](https://github.com/getsolus/help-center-docs/issues/643)
