### PR TITLE
github: Update deploy workflow to not use deprecated option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           cache: yarn
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
       - name: Build website
         run: yarn build
 


### PR DESCRIPTION
## Description

Update `yarn` command in the deploy action to not use a deprecated flag.
