### PR TITLE
Remove references to Clear Linux

### DIFF
--- a/docs/user/quick-start/boot-management.md
+++ b/docs/user/quick-start/boot-management.md
@@ -3,7 +3,7 @@ title: Boot management
 summary: Guide to customizing the Solus boot process
 ---
 
-Solus uses `clr-boot-manager` from the Clear Linux project to handle all boot configuration. This tool automatically configures the appropriate boot loader based on your system type:
+Solus uses `clr-boot-manager` to handle all boot configuration. This tool automatically configures the appropriate boot loader based on your system type:
 
 - Legacy BIOS systems: GRUB2
 - Modern UEFI systems: `systemd-boot`

--- a/docs/user/quick-start/kernel-management/remove-old-kernels.md
+++ b/docs/user/quick-start/kernel-management/remove-old-kernels.md
@@ -5,7 +5,7 @@ summary: Manage and remove old kernels to free up space on the boot partition.
 You might need to remove old kernels for various reasons:
 
 - The boot partition is too small for multiple kernel versions
-- [`clr-boot-manager`](https://github.com/clearlinux/clr-boot-manager) not automatically cleaning up old entries
+- [`clr-boot-manager`](https://github.com/getsolus/clr-boot-manager) not automatically cleaning up old entries
 - Custom or testing kernels installed that won't be automatically removed
 
 If the boot partition of your system is full, updates might fail and you might not be able to install new kernels.


### PR DESCRIPTION
## Description

<Describe what this pull request adds>
As Clear Linux is now defunct, we should move all references to their sites and documentations to our own domain.