### PR TITLE
Third Party: Add python-eopkg requirement, update commands

### DIFF
--- a/docs/user/software/third-party/index.md
+++ b/docs/user/software/third-party/index.md
@@ -11,7 +11,7 @@ If these instructions fail to work please [file an issue](https://github.com/get
 
 ## Prerequisites
 
-To run any of these commands you must first install the `python-eopkg` package
+To run any of these commands, you must first install the `python-eopkg` package
 
 ```bash
 sudo eopkg it python-eopkg


### PR DESCRIPTION
## Description

Add `python-eopkg` as a prerequisite for Third Party Repository commands and update the commands accordingly.

Also remove outdated reference to (old) Software Center
