### PR TITLE
docs: Add documentation for the %install_license macro

### DIFF
--- a/docs/packaging/package.yml.md
+++ b/docs/packaging/package.yml.md
@@ -165,6 +165,7 @@ Macros are prefixed with `%`, and are substituted before your script is executed
 | **%apply_patches**            | Applies all patches listed in the `series` file in `./files` folder.                                                                      |
 | **%reconfigure**              | Updates build scripts such as `./configure` and proceeds to run `%configure`.                                                             |
 | **%symlink_check**            | Checks for broken symlinks in the install directory and aborts the build if any are found. Must run after install macros.                 |
+| **%install_license**          | Installs any files after the macro to `$installdir/usr/share/licenses/$package/`. |
 
 ### Haskell actionable macros
 

--- a/docs/packaging/packaging-changes.md
+++ b/docs/packaging/packaging-changes.md
@@ -13,6 +13,19 @@ This page is meant to serve as a changelog of sorts for the Solus packaging envi
 
 ## 2025
 
+### December
+
+#### Mandate installation of license files
+
+- Packages must now have license files installed so we are compliant.
+- License files can be easily installed with the new `%install_license` macro.
+  ```yaml
+  install    : |
+      %ninja_install
+      %install_license LICENSE
+      %install_license LICENSES/*
+  ```
+
 ### November
 
 #### Initial language server integration for `package.yml` files

--- a/docs/packaging/packaging-practices.md
+++ b/docs/packaging/packaging-practices.md
@@ -90,6 +90,15 @@ All new packages or updates to packages should abide by the [SPDX 3.x](https://s
 
 - `-only` licenses, such as `GPL-2.0-only`, should **only be declared** as such when the upstream explicitly states "only", otherwise it should always be `-or-later`.
 
+License files that are present in an upstream project must also be installed with the package. This can be easily done with the `%install_license` macro. The macro will install any files passed to it to the system licenses directory, `$installdir/usr/share/licenses/$package/`. The files passed to the macro are expected to be relative to the project's source root.
+
+```yaml
+install    : |
+    %ninja_install
+    %install_license LICENSE
+    %install_license LICENSES/*
+```
+
 ## Build dependencies
 
 :::note


### PR DESCRIPTION
## Description

Adds documentation for the new `%install_license` macro.
