### PR TITLE
docs: remove link to old "tooling central" doc

### DIFF
--- a/docs/packaging/creating-a-new-package.md
+++ b/docs/packaging/creating-a-new-package.md
@@ -189,8 +189,6 @@ Resolves getsolus/packages#issuenumber
 
 Where `issuenumber` is the issue number of the package request.
 
-For more information on suitable commit messages, please check the [tooling central documentation](https://github.com/solus-project/tooling-central/blob/master/README.rst#using-git).
-
 If you need a change to depend on another change, mention it in the commit message too (use the full URL): `Depends on https://github.com/getsolus/packages/issues/234`
 
 Next, you'll [submit a pull request for review](submitting-a-pull-request.mdx).

--- a/docs/packaging/updating-an-existing-package.md
+++ b/docs/packaging/updating-an-existing-package.md
@@ -185,6 +185,4 @@ In the cases where you are not updating a package to a new version, but simply a
 
 As stated previously, `[NFC]` is an abbreviation of "No Functional Change".
 
-For more information on suitable commit messages, please check the [tooling central documentation](https://github.com/solus-project/tooling-central/blob/master/README.rst#using-git).
-
 Next, you'll [submit a pull request for review](submitting-a-pull-request.mdx).


### PR DESCRIPTION
These "tooling central" links are very disconnected from what we expect from day-to-day packaging work. Remove them.