### PR TITLE
index: Make the homepage header look more like the main site

### DIFF
--- a/src/components/home/Header.tsx
+++ b/src/components/home/Header.tsx
@@ -1,0 +1,32 @@
+import { Stack, Typography } from "@mui/material";
+
+export const Header = () => {
+  return (
+    <Stack
+      alignItems="center"
+      justicyContent="center"
+      paddingY={{ sm: '2.5rem', md: '3rem', lg: '3.5rem' }}
+      spacing='1.25rem'
+    >
+      <Typography
+        style={{
+          fontSize: '3rem',
+          fontWeight: 600,
+          lineHeight: 1.25,
+          textAlign: 'center',
+        }}
+        variant="h1"
+      >
+        Solus Help Center
+      </Typography>
+      <Typography
+        style={{
+          fontSize: '1.25rem',
+          fontStyle: 'italic',
+        }}
+      >
+        Documentation for Solus
+      </Typography>
+    </Stack>
+  );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,6 +12,8 @@ import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined
 import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
 import EngineeringOutlinedIcon from "@mui/icons-material/EngineeringOutlined";
 
+import { Header } from "../components/home/Header";
+
 import clsx from "clsx";
 
 import styles from "./styles.module.css";
@@ -62,22 +64,12 @@ const Card = (item: DocSection) => {
   );
 };
 
-const Docs = () => {
+const Home = (): JSX.Element => {
   return (
     <Layout title="Documentation" description="Solus">
+      <Header />
+
       <Container sx={{ marginBlock: "4vh" }}>
-        <Stack
-          className="hero hero--secondary"
-          alignItems="center"
-          justifyContent="center"
-          padding="5vh 10vw"
-          spacing={2}
-        >
-          <Heading as="h1" className="hero__title">
-            Solus Help Center
-          </Heading>
-          <p className="hero__subtitle">Documentation for Solus</p>
-        </Stack>
         <section className="row">
           {sections.map((section, index) => (
             <article key={index} className="col col--6 margin-bottom--lg">
@@ -96,4 +88,4 @@ const Docs = () => {
   );
 };
 
-export default Docs;
+export default Home;


### PR DESCRIPTION
## Description

Makes the page header on the homepage look more like the page headers on the main Solus website.

