### PR TITLE
Third Party: Update commands to use eopkg.py

### DIFF
--- a/docs/user/software/third-party/index.md
+++ b/docs/user/software/third-party/index.md
@@ -22,21 +22,21 @@ sudo eopkg it python-eopkg
 ### Google Chrome
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-stable/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-stable/pspec.xml
 sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ```
 
 ### Google Chrome (Beta)
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-beta/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-beta/pspec.xml
 sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ```
 
 ### Google Chrome (Dev/Unstable)
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-unstable/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-unstable/pspec.xml
 sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ```
 
@@ -45,21 +45,21 @@ sudo eopkg it google-chrome-*.eopkg;sudo rm google-chrome-*.eopkg
 ### Franz
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/franz/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/franz/pspec.xml
 sudo eopkg it franz*.eopkg;sudo rm franz*.eopkg
 ```
 
 ### Slack
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/slack-desktop/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/slack-desktop/pspec.xml
 sudo eopkg it slack-desktop*.eopkg;sudo rm slack-desktop*.eopkg
 ```
 
 ### Viber
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/viber/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/im/viber/pspec.xml
 sudo eopkg it viber*.eopkg;sudo rm *.eopkg
 ```
 
@@ -68,21 +68,21 @@ sudo eopkg it viber*.eopkg;sudo rm *.eopkg
 ### Bitwig Studio
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/bitwig-studio/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/bitwig-studio/pspec.xml
 sudo eopkg it bitwig-studio*.eopkg;sudo rm bitwig-studio*.eopkg
 ```
 
 ### Ocenaudio
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/ocenaudio/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/ocenaudio/pspec.xml
 sudo eopkg it ocenaudio*.eopkg;sudo rm ocenaudio*.eopkg
 ```
 
 ### Plex Media Server
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/video/plexmediaserver/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/video/plexmediaserver/pspec.xml
 sudo eopkg it plexmediaserver-*.eopkg;sudo rm plexmediaserver-*.eopkg
 sudo systemd-tmpfiles --create
 sudo systemctl start plexmediaserver.service
@@ -97,14 +97,14 @@ sudo systemctl enable plexmediaserver.service
 ### SunVox
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/sunvox/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/sunvox/pspec.xml
 sudo eopkg it sunvox*.eopkg;sudo rm sunvox*.eopkg
 ```
 
 ### Spotify
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/spotify/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/multimedia/music/spotify/pspec.xml
 sudo eopkg it spotify*.eopkg;sudo rm spotify*.eopkg
 ```
 
@@ -113,35 +113,35 @@ sudo eopkg it spotify*.eopkg;sudo rm spotify*.eopkg
 ### AnyDesk
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/util/anydesk/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/util/anydesk/pspec.xml
 sudo eopkg it anydesk*.eopkg;sudo rm anydesk*.eopkg
 ```
 
 ### Insync
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/insync/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/insync/pspec.xml
 sudo eopkg it insync*.eopkg;sudo rm insync*.eopkg
 ```
 
 ### Spideroak
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/spideroak/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/spideroak/pspec.xml
 sudo eopkg it spideroak*.eopkg;sudo rm spideroak*.eopkg
 ```
 
 ### Synology Cloud Station Drive
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/synology-cloud-station-drive/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/download/synology-cloud-station-drive/pspec.xml
 sudo eopkg it synology-cloud-station-drive*.eopkg;sudo rm synology-cloud-station-drive*.eopkg
 ```
 
 ### TeamViewer
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/util/teamviewer/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/util/teamviewer/pspec.xml
 sudo eopkg it teamviewer*.eopkg;sudo rm teamviewer*.eopkg
 sudo systemctl start teamviewerd.service
 ```
@@ -151,35 +151,35 @@ sudo systemctl start teamviewerd.service
 ### Mendeley Desktop
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/mendeleydesktop/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/mendeleydesktop/pspec.xml
 sudo eopkg it mendeleydesktop*.eopkg;sudo rm mendeleydesktop*.eopkg
 ```
 
 ### Microsoft Core Fonts
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/desktop/font/mscorefonts/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/desktop/font/mscorefonts/pspec.xml
 sudo eopkg it mscorefonts*.eopkg;sudo rm mscorefonts*.eopkg
 ```
 
 ### Moneydance
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/moneydance/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/moneydance/pspec.xml
 sudo eopkg it moneydance*.eopkg;sudo rm moneydance*.eopkg
 ```
 
 ### PomoDoneApp
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/pomodoneapp/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/pomodoneapp/pspec.xml
 sudo eopkg it pomodoneapp*.eopkg;sudo rm pomodoneapp*.eopkg
 ```
 
 ### Scrivener
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/scrivener/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/office/scrivener/pspec.xml
 sudo eopkg it scrivener*.eopkg;sudo rm scrivener*.eopkg
 ```
 
@@ -188,77 +188,77 @@ sudo eopkg it scrivener*.eopkg;sudo rm scrivener*.eopkg
 ### Android Studio
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/android-studio/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/android-studio/pspec.xml
 sudo eopkg it android-studio*.eopkg;sudo rm android-studio*.eopkg
 ```
 
 ### CLion
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/clion/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/clion/pspec.xml
 sudo eopkg it clion*.eopkg;sudo rm clion*.eopkg
 ```
 
 ### DataGrip
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/datagrip/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/datagrip/pspec.xml
 sudo eopkg it datagrip*.eopkg;sudo rm datagrip*.eopkg
 ```
 
 ### GitKraken
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/gitkraken/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/gitkraken/pspec.xml
 sudo eopkg it gitkraken*.eopkg;sudo rm gitkraken*.eopkg
 ```
 
 ### IDEA
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/idea/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/idea/pspec.xml
 sudo eopkg it idea*.eopkg;sudo rm idea*.eopkg
 ```
 
 ### PhpStorm
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/phpstorm/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/phpstorm/pspec.xml
 sudo eopkg it phpstorm*.eopkg;sudo rm phpstorm*.eopkg
 ```
 
 ### PyCharm
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/pycharm/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/pycharm/pspec.xml
 sudo eopkg it pycharm*.eopkg;sudo rm pycharm*.eopkg
 ```
 
 ### Rider
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/rider/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/rider/pspec.xml
 sudo eopkg it rider*.eopkg;sudo rm rider*.eopkg
 ```
 
 ### RubyMine
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/rubymine/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/rubymine/pspec.xml
 sudo eopkg it rubymine*.eopkg;sudo rm rubymine*.eopkg
 ```
 
 ### Sublime Text
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/sublime-text/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/sublime-text/pspec.xml
 sudo eopkg it sublime*.eopkg;sudo rm sublime*.eopkg
 ```
 
 ### WebStorm
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/webstorm/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/programming/webstorm/pspec.xml
 sudo eopkg it webstorm*.eopkg;sudo rm webstorm*.eopkg
 ```
 
@@ -267,7 +267,7 @@ sudo eopkg it webstorm*.eopkg;sudo rm webstorm*.eopkg
 ### Enpass
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/security/enpass/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/security/enpass/pspec.xml
 sudo eopkg it enpass*.eopkg;sudo rm enpass*.eopkg
 ```
 
@@ -276,6 +276,6 @@ sudo eopkg it enpass*.eopkg;sudo rm enpass*.eopkg
 ### Google Earth
 
 ```bash
-sudo eopkg.py3 bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/google-earth/pspec.xml
+sudo eopkg.py bi --ignore-safety https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/google-earth/pspec.xml
 sudo eopkg it google-earth*.eopkg;sudo rm google-earth*.eopkg
 ```


### PR DESCRIPTION
## Description

Update the Third Party build commands to use `eopkg.py`

To be merged after the next sync, which includes the `python-eopkg` change that renames `eopkg.py3` to `eopkg.py`
