### PR TITLE
fix: Improve docs on contacting maintainers

### DIFF
--- a/docs/packaging/procedures/maintainership.md
+++ b/docs/packaging/procedures/maintainership.md
@@ -15,25 +15,25 @@ Each new package which is going to land in the Solus repository must have one or
 - Ensure the [packaging file](/docs/packaging/package.yml) adheres to the Solus [standards](/docs/packaging/packaging-practices)
 - Ensure the application or library is consistent with the Operating System aesthetics, file system conventions and the Solus philosophy in general
 
-On the Solus side however, the community must not forget that maintainers are volunteers, which may or may not have a technical background. More experienced users are to engage new maintainers in a welcoming manner, e.g. by listing their errors and inviting them to fix them. (More on this in the [community guidelines](/docs/user/contributing/community-guidelines#repositories-and-issue-trackers))
+The Solus community must not forget that maintainers are volunteers, who may or may not have a technical background. More experienced users are to engage new maintainers in a welcoming manner, e.g. by listing their errors and inviting them to fix them. (More on this in the [community guidelines](/docs/user/contributing/community-guidelines#repositories-and-issue-trackers))
 
 The Solus Staff have the right to enforce certain practices, even when in contrast with maintainers' vision. It also has the right to ultimately accept or reject a patch.
 
-## Stepping in
+## Becoming the maintainer of a package
 
-To officially step in as the maintainer of a package, a `MAINTAINERS.md` file must be provided for accepted packages that are not yet included in the repository, or if the package predates the policy of requiring one. Instead, if a previously maintained package is marked by Solus Staff as needing a new maintainer, the `MAINTAINERS.md` file must be updated.
+To officially step in as the maintainer of a new package, a `MAINTAINERS.md` file must be provided for packages that have an approved package addition request, but are not yet included in the repository. If a previously maintained package is marked by Solus Staff as needing a new maintainer, the `MAINTAINERS.md` file must be updated.
 
 ## Updating a maintained package
 
-The procedure varies depending on whether or not the individual is the maintainer.
+This procedure varies, depending on whether or not the person wanting to update the package is one of its maintainers.
 
-### Maintainers
+### For the package maintainer(s)
 
-Maintainers are free to [update a package](/docs/packaging/updating-an-existing-package) at their will, unless otherwise indicated by Solus Staff.
+Maintainers listed in `MAINTAINERS.md` are free to [update a package](/docs/packaging/updating-an-existing-package) at their discretion, unless otherwise indicated by Solus Staff.
 
-### Non-maintainers
+### For non-maintainers
 
-If a package is actively maintained, modifications should not occur and the individual should exercise patience when it comes to updates. In some cases, a maintainer may intentionally be holding back a package, or has simply not updated yet. If pertinent, the individual should file a [package update request](/docs/packaging/procedures/request-a-package-update). Alternatively, the individual can reach the maintainers or Solus Staff via the Solus Packaging room on [Matrix](/docs/user/contributing/getting-involved#matrix-chat) and ask permission to update the package. It is also possible to submit an update and attach a message to it clarifying the intention of updating the package, although this is a special case reserved to e.g. security updates.
+If a package is actively maintained, individuals who are not one of its maintainers should not submit updates. Rather, they should exercise patience. In some cases, a maintainer may be intentionally holding back a package, or has simply not updated it yet. If pertinent, the individual who wants the update should file a [package update request](/docs/packaging/procedures/request-a-package-update). Alternatively, they can ask the maintainers via their provided contact information, or Solus Staff via the Solus Packaging room on [Matrix](/docs/user/contributing/getting-involved#matrix-chat) for permission to update the package. Note: When contacting a maintainer on Matrix, it's preferred to mention them in the Packaging room before trying to send private messages. For special circumstances, such as with security updates, it's possible to submit an update with a message in the PR clarifying the author's intention in updating the package.
 
 ## Template for the `MAINTAINERS.md` file
 

--- a/docs/packaging/updating-an-existing-package.md
+++ b/docs/packaging/updating-an-existing-package.md
@@ -11,16 +11,14 @@ This article will go over updating a package that is already in the Solus packag
 :::note
 
 **Please [look to see if an issue has been filed](https://github.com/getsolus/packages/labels/Package%3A%20Update%20Request) for the software update**.
-If there is an existing request, please add a link to it in your pull request. Ex:
+If there is an existing request, please add a link to it in your pull request. This will automatically close the related issue. You just need to use `#123`, GitHub will automatically link to the issue. Ex:
 
 ```
-This PR resolves software update request https://github.com/getsolus/packages/issues/123
+This PR fixes #123
 ```
 
 **Also check to see if there's already an active maintainer**
-If there's a MAINTAINER.md file, see [this](https://help.getsol.us/docs/packaging/procedures/maintainership).
-Please contact the maintainer listed in that file, or [create a package update request](https://github.com/getsolus/packages/labels/Package%3A%20Update%20Request) before attempting to update the package.
-
+If there's a MAINTAINER.md file, stop and read over [Maintainership - Updating a maintained package](https://help.getsol.us/docs/packaging/procedures/maintainership/#updating-a-maintained-package) to see how to handle this.
 :::
 
 ### Update your clone of the packages repository


### PR DESCRIPTION
Remove conflicting instructions about a package with a maintainer and refer to existing information in Maintainership

Update wording to be consistent with GitHub rather than Phabricator

Grammatical improvements
