### PR TITLE
css: Set a color for the page background

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -9,6 +9,7 @@
   --marble: #f1f1f1;
   --dark: #1f1f1f;
 
+  --ifm-background-color: #fff;
   --ifm-card-background-color: var(--marble);
   --ifm-color-primary: #2374d3;
   --ifm-color-primary-dark: #2068be;
@@ -25,6 +26,7 @@
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme="dark"] {
+  --ifm-background-color: #111;
   --ifm-card-background-color: var(--dark);
   --ifm-color-primary: #5294e2;
   --ifm-color-primary-dark: #3884de;


### PR DESCRIPTION
## Description

For some reason, by default, the webpage background is transparent. Let's set it to an actual color. This is really only a problem for people that use modified styles for their web browser, but that happens to include me, and the Help Center is really hard to use when it is transparent. These colors match the main Solus website.
