### PR TITLE
meta: Switch to tag based deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches:
-      - deploy
+    tags:
+      - v*
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ To start the live reloading Docusaurus, run: `yarn start`
 
 Ensure that you can successfully generate a static site as above.
 
-Then, when you're ready to deploy, run the following:
+When ready to deploy:
 
-`go-task deploy`
+- Create a new tag. Tags have the form "v[version number]", where version number goes up by 1 each new tag.
+- Push the tag to the repository. This triggers the GitHub Pages deployment.
+- OR use `go-task deploy` to do these steps automatically.
 
 This obviously assumes that you have ssh push access to the `help-center-docs` repository and are using `remote.origin.url=git@github.com:getsolus/help-center-docs.git` (as listed by `git config -l`).
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,16 +13,17 @@ tasks:
       - |
         echo "Use 'go-task -l/--list' to list available tasks."
 
-  # Merge "master" into "deploy" branch for GitHub pages deployment
   deploy:
-    desc: Merge the "master" branch into "deploy" to start GitHub Pages build
+    desc: Trigger a GH Pages deployment by pushing a new tag for the lastest commit in master. Don't repeatedly tag the same commit with this task, start the deploy Action if needed.
+    vars:
+      NEW_VERSION_NUMBER:
+        sh: git describe --tags  | cut --delimiter "v" --fields 2- | xargs -n 1 expr 1 + # get the latest tag | trim off "v" | increment the result by 1
     cmds:
       - git switch master
       - git pull origin master
-      - git switch deploy
-      - git merge master
-      - git push origin deploy
-      - git switch master
+      - git tag -a v{{.NEW_VERSION_NUMBER}} -m ""
+      - git push tags
+
 
   # Tidy up the allowed-words list
   tidy-words:


### PR DESCRIPTION
- Switch to deploying GitHub Pages based on tags, rather than pushes to the "deploy" branch
- I have arbitrarily decided that tags should look like v1, v2, ..., v15. An incrementing integer prefixed by "v"